### PR TITLE
fix: strip OpenClaw inbound metadata before MemOS sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ import {
   extractResultData,
   extractText,
   formatRecallHookResult,
-  USER_QUERY_MARKER,
   searchMemory,
+  stripOpenClawInjectedPrefix,
 } from "./lib/memos-cloud-api.js";
 import { startUpdateChecker } from "./lib/check-update.js";
 let lastCaptureTime = 0;
@@ -31,13 +31,6 @@ function warnMissingApiKey(log, context) {
       `Get API key: ${API_KEY_HELP_URL}`,
     ].join("\n"),
   );
-}
-
-function stripPrependedPrompt(content) {
-  if (!content) return content;
-  const idx = content.lastIndexOf(USER_QUERY_MARKER);
-  if (idx === -1) return content;
-  return content.slice(idx + USER_QUERY_MARKER.length).trimStart();
 }
 
 function getCounterSuffix(sessionKey) {
@@ -73,7 +66,8 @@ function resolveConversationId(cfg, ctx) {
 }
 
 function buildSearchPayload(cfg, prompt, ctx) {
-  const queryRaw = `${cfg.queryPrefix || ""}${prompt}`;
+  const cleanPrompt = stripOpenClawInjectedPrefix(prompt);
+  const queryRaw = `${cfg.queryPrefix || ""}${cleanPrompt}`;
   const query =
     Number.isFinite(cfg.maxQueryChars) && cfg.maxQueryChars > 0
       ? queryRaw.slice(0, cfg.maxQueryChars)
@@ -162,7 +156,7 @@ function pickLastTurnMessages(messages, cfg) {
   for (const msg of slice) {
     if (!msg || !msg.role) continue;
     if (msg.role === "user") {
-      const content = stripPrependedPrompt(extractText(msg.content));
+      const content = stripOpenClawInjectedPrefix(extractText(msg.content));
       if (content) results.push({ role: "user", content: truncate(content, cfg.maxMessageChars) });
       continue;
     }
@@ -180,7 +174,7 @@ function pickFullSessionMessages(messages, cfg) {
   for (const msg of messages) {
     if (!msg || !msg.role) continue;
     if (msg.role === "user") {
-      const content = stripPrependedPrompt(extractText(msg.content));
+      const content = stripOpenClawInjectedPrefix(extractText(msg.content));
       if (content) results.push({ role: "user", content: truncate(content, cfg.maxMessageChars) });
     }
     if (msg.role === "assistant" && cfg.includeAssistant) {
@@ -426,18 +420,19 @@ export default {
 
     api.on("before_agent_start", async (event, ctx) => {
       if (!cfg.recallEnabled) return;
-      if (!event?.prompt || event.prompt.length < 3) return;
+      const userPrompt = stripOpenClawInjectedPrefix(event?.prompt || "");
+      if (!userPrompt || userPrompt.length < 3) return;
       if (!cfg.apiKey) {
         warnMissingApiKey(log, "recall");
         return;
       }
 
       try {
-        const payload = buildSearchPayload(cfg, event.prompt, ctx);
+        const payload = buildSearchPayload(cfg, userPrompt, ctx);
         const result = await searchMemory(cfg, payload);
         const resultData = extractResultData(result);
         if (!resultData) return;
-        const filteredData = await maybeFilterRecallData(cfg, resultData, event.prompt, log);
+        const filteredData = await maybeFilterRecallData(cfg, resultData, userPrompt, log);
         const hookResult = formatRecallHookResult({ data: filteredData }, {
           wrapTagBlocks: true,
           relativity: payload.relativity,

--- a/lib/memos-cloud-api.js
+++ b/lib/memos-cloud-api.js
@@ -5,6 +5,14 @@ import { setTimeout as delay } from "node:timers/promises";
 
 const DEFAULT_BASE_URL = "https://memos.memtensor.cn/api/openmem/v1";
 export const USER_QUERY_MARKER = "user\u200b原\u200b始\u200bquery\u200b：\u200b\u200b\u200b\u200b";
+const INBOUND_META_SENTINELS = [
+  "Conversation info (untrusted metadata):",
+  "Sender (untrusted metadata):",
+  "Thread starter (untrusted, for context):",
+  "Replied message (untrusted, for context):",
+  "Forwarded message context (untrusted metadata):",
+  "Chat history since last reply (untrusted, for context):",
+];
 const ENV_SOURCES = [
   { name: "openclaw", path: join(homedir(), ".openclaw", ".env") },
   { name: "moltbot", path: join(homedir(), ".moltbot", ".env") },
@@ -268,6 +276,56 @@ export async function searchMemory(cfg, payload) {
 
 export async function addMessage(cfg, payload) {
   return callApi(cfg, "/add/message", payload);
+}
+
+function isInboundMetaSentinelLine(line) {
+  const trimmed = line.trim();
+  return INBOUND_META_SENTINELS.some((sentinel) => sentinel === trimmed);
+}
+
+function stripLeadingInboundMetadata(text) {
+  if (!text || typeof text !== "string") return "";
+  const lines = text.split(/\r?\n/);
+  let index = 0;
+  let strippedAny = false;
+
+  while (index < lines.length && lines[index].trim() === "") {
+    index += 1;
+  }
+  if (index >= lines.length || !isInboundMetaSentinelLine(lines[index])) {
+    return text;
+  }
+
+  while (index < lines.length) {
+    if (!isInboundMetaSentinelLine(lines[index])) break;
+    const blockStart = index;
+    index += 1;
+    if (index >= lines.length || lines[index].trim() !== "```json") {
+      return strippedAny ? lines.slice(blockStart).join("\n") : text;
+    }
+    index += 1;
+    while (index < lines.length && lines[index].trim() !== "```") {
+      index += 1;
+    }
+    if (index >= lines.length) {
+      return strippedAny ? lines.slice(blockStart).join("\n") : text;
+    }
+    index += 1;
+    strippedAny = true;
+    while (index < lines.length && lines[index].trim() === "") {
+      index += 1;
+    }
+  }
+
+  return lines.slice(index).join("\n");
+}
+
+export function stripOpenClawInjectedPrefix(text) {
+  if (!text || typeof text !== "string") return "";
+  const markerIndex = text.lastIndexOf(USER_QUERY_MARKER);
+  const withoutRecallPrefix =
+    markerIndex === -1 ? text : text.slice(markerIndex + USER_QUERY_MARKER.length);
+  return stripLeadingInboundMetadata(withoutRecallPrefix).trimStart();
 }
 
 export function extractText(content) {

--- a/test/query-strip.test.mjs
+++ b/test/query-strip.test.mjs
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  USER_QUERY_MARKER,
+  stripOpenClawInjectedPrefix,
+} from "../lib/memos-cloud-api.js";
+
+test("leaves plain user text unchanged", () => {
+  assert.equal(stripOpenClawInjectedPrefix("直接就是用户问题"), "直接就是用户问题");
+});
+
+test("strips MemOS recall marker and keeps original query", () => {
+  const input = `<memories>\n  <facts>\n  </facts>\n</memories>\n\n${USER_QUERY_MARKER}真正的问题`;
+  assert.equal(stripOpenClawInjectedPrefix(input), "真正的问题");
+});
+
+test("strips OpenClaw inbound metadata prefix blocks", () => {
+  const input = [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    '{"message_id":"123"}',
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "```json",
+    '{"label":"Aurora"}',
+    "```",
+    "",
+    "帮我看下这个问题",
+  ].join("\n");
+
+  assert.equal(stripOpenClawInjectedPrefix(input), "帮我看下这个问题");
+});
+
+test("strips recall marker and inbound metadata together", () => {
+  const input = [
+    "<memories>",
+    "  <facts>",
+    "  </facts>",
+    "</memories>",
+    "",
+    `${USER_QUERY_MARKER}Conversation info (untrusted metadata):`,
+    "```json",
+    '{"message_id":"123","history_count":1}',
+    "```",
+    "",
+    "Chat history since last reply (untrusted, for context):",
+    "```json",
+    '[{"sender":"Aurora","body":"上一条"}]',
+    "```",
+    "",
+    "继续",
+  ].join("\n");
+
+  assert.equal(stripOpenClawInjectedPrefix(input), "继续");
+});
+
+test("keeps content when metadata block is malformed", () => {
+  const input = [
+    "Conversation info (untrusted metadata):",
+    "not-a-json-fence",
+    "真正的问题",
+  ].join("\n");
+
+  assert.equal(stripOpenClawInjectedPrefix(input), input);
+});
+
+test("keeps content unchanged when sentinel appears in normal body", () => {
+  const input = [
+    "请原样解释下面这段文本：",
+    "Conversation info (untrusted metadata):",
+    "```json",
+    '{"message_id":"123"}',
+    "```",
+  ].join("\n");
+
+  assert.equal(stripOpenClawInjectedPrefix(input), input);
+});
+
+test("strips valid prefix even if body starts with a sentinel-like line", () => {
+  const input = [
+    "Sender (untrusted metadata):",
+    "```json",
+    '{"label":"Aurora"}',
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "这行是正文，不是 OpenClaw 注入块",
+  ].join("\n");
+
+  assert.equal(
+    stripOpenClawInjectedPrefix(input),
+    ["Sender (untrusted metadata):", "这行是正文，不是 OpenClaw 注入块"].join("\n"),
+  );
+});
+
+test("supports leading blank lines before inbound metadata", () => {
+  const input = [
+    "",
+    "",
+    "Conversation info (untrusted metadata):",
+    "```json",
+    '{"message_id":"123"}',
+    "```",
+    "",
+    "真正的问题",
+  ].join("\n");
+
+  assert.equal(stripOpenClawInjectedPrefix(input), "真正的问题");
+});
+
+test("supports windows newlines", () => {
+  const input =
+    "Conversation info (untrusted metadata):\r\n```json\r\n{\"message_id\":\"123\"}\r\n```\r\n\r\n继续";
+
+  assert.equal(stripOpenClawInjectedPrefix(input), "继续");
+});


### PR DESCRIPTION
## Fix

- strip OpenClaw injected inbound metadata blocks before sending `/search/memory` queries
- strip the same prefix before writing user turns into `/add/message`
- centralize the cleanup logic in a shared helper so recall/add stay consistent
- keep the parser fail-open so non-matching or malformed inputs do not break existing behavior

## Changes

- add `stripOpenClawInjectedPrefix` in `lib/memos-cloud-api.js`
- apply the helper in recall query building and both message capture paths in `index.js`
- add regression tests for plain text, recall marker, inbound metadata blocks, malformed blocks, sentinel-like body text, leading blanks, and Windows newlines

## Test Report

- `node --test test/query-strip.test.mjs`
- `node -e "import('./index.js').then(() => console.log('index import ok'))"`

Results:

- 9/9 tests passed
- plugin entry import check passed
