### PR TITLE
feat: add switches to disable automatic recall/add hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,10 @@ In `plugins.entries.memos-cloud-openclaw-plugin.config`:
   "conversationId": "openclaw-main",
   "queryPrefix": "important user context preferences decisions ",
   "recallEnabled": true,
+  "disableAutoSearchMemory": false,
   "recallGlobal": true,
   "addEnabled": true,
+  "disableAutoAddMessage": false,
   "captureStrategy": "last_turn",
   "maxItemChars": 8000,
   "includeAssistant": true,
@@ -152,12 +154,14 @@ In `plugins.entries.memos-cloud-openclaw-plugin.config`:
 ## How it Works
 - **Recall** (`before_agent_start`)
   - Builds a `/search/memory` request using `user_id`, `query` (= prompt + optional prefix), and optional filters.
+  - Set `disableAutoSearchMemory=true` to skip the automatic `/search/memory` call.
   - Default **global recall**: when `recallGlobal=true`, it does **not** pass `conversation_id`.
   - Optional second-pass filtering: if `recallFilterEnabled=true`, candidates are sent to your configured model and only returned `keep` items are injected.
   - Injects a stable MemOS recall protocol via `appendSystemContext`, while the retrieved `<memories>` block remains in `prependContext`.
 
 - **Add** (`agent_end`)
   - Builds a `/add/message` request with the **last turn** by default (user + assistant).
+  - Set `disableAutoAddMessage=true` to skip the automatic `/add/message` call while keeping recall enabled.
   - Sends `messages` with `user_id`, `conversation_id`, and optional `tags/info/agent_id/app_id`.
 
 ## Multi-Agent Support

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -119,8 +119,10 @@ MEMOS_API_KEY=YOUR_TOKEN
   "conversationId": "openclaw-main",
   "queryPrefix": "important user context preferences decisions ",
   "recallEnabled": true,
+  "disableAutoSearchMemory": false,
   "recallGlobal": true,
   "addEnabled": true,
+  "disableAutoAddMessage": false,
   "captureStrategy": "last_turn",
   "includeAssistant": true,
   "conversationIdPrefix": "",
@@ -153,6 +155,7 @@ MEMOS_API_KEY=YOUR_TOKEN
 ### 1) 召回（before_agent_start）
 - 组装 `/search/memory` 请求
   - `user_id`、`query`（= prompt + 可选前缀）
+  - 若设置 `disableAutoSearchMemory=true`，会跳过自动 `/search/memory`
   - 默认**全局召回**：`recallGlobal=true` 时不传 `conversation_id`
   - 可选 `filter` / `knowledgebase_ids`
 - （可选）若开启 `recallFilterEnabled`，会先把 `memory/preference/tool_memory` 候选发给你配置的模型做二次筛选，只保留 `keep` 的条目
@@ -160,6 +163,7 @@ MEMOS_API_KEY=YOUR_TOKEN
 
 ### 2) 添加（agent_end）
 - 默认只写**最后一轮**（user + assistant）
+- 若设置 `disableAutoAddMessage=true`，会跳过自动 `/add/message`，但不影响 recall。
 - 构造 `/add/message` 请求：
   - `user_id`、`conversation_id`
   - `messages` 列表

--- a/clawdbot.plugin.json
+++ b/clawdbot.plugin.json
@@ -57,6 +57,11 @@
         "type": "boolean",
         "default": true
       },
+      "disableAutoSearchMemory": {
+        "type": "boolean",
+        "description": "Disable the automatic /search/memory call on before_agent_start",
+        "default": false
+      },
       "recallGlobal": {
         "type": "boolean",
         "default": true
@@ -64,6 +69,11 @@
       "addEnabled": {
         "type": "boolean",
         "default": true
+      },
+      "disableAutoAddMessage": {
+        "type": "boolean",
+        "description": "Disable the automatic /add/message call on agent_end",
+        "default": false
       },
       "captureStrategy": {
         "type": "string",

--- a/index.js
+++ b/index.js
@@ -419,7 +419,7 @@ export default {
     }
 
     api.on("before_agent_start", async (event, ctx) => {
-      if (!cfg.recallEnabled) return;
+      if (!cfg.recallEnabled || cfg.disableAutoSearchMemory) return;
       const userPrompt = stripOpenClawInjectedPrefix(event?.prompt || "");
       if (!userPrompt || userPrompt.length < 3) return;
       if (!cfg.apiKey) {
@@ -447,7 +447,7 @@ export default {
     });
 
     api.on("agent_end", async (event, ctx) => {
-      if (!cfg.addEnabled) return;
+      if (!cfg.addEnabled || cfg.disableAutoAddMessage) return;
       if (!event?.success || !event?.messages?.length) return;
       if (!cfg.apiKey) {
         warnMissingApiKey(log, "add");

--- a/lib/memos-cloud-api.js
+++ b/lib/memos-cloud-api.js
@@ -173,6 +173,8 @@ export function buildConfig(pluginConfig = {}) {
     cfg.recallFilterFailOpen,
     parseBool(loadEnvVar("MEMOS_RECALL_FILTER_FAIL_OPEN"), true),
   );
+  const disableAutoSearchMemory = parseBool(cfg.disableAutoSearchMemory, false);
+  const disableAutoAddMessage = parseBool(cfg.disableAutoAddMessage, false);
 
   return {
     baseUrl: baseUrl.replace(/\/+$/, ""),
@@ -188,7 +190,9 @@ export function buildConfig(pluginConfig = {}) {
     queryPrefix: cfg.queryPrefix ?? "",
     maxQueryChars: cfg.maxQueryChars ?? 0,
     recallEnabled: cfg.recallEnabled !== false,
+    disableAutoSearchMemory,
     addEnabled: cfg.addEnabled !== false,
+    disableAutoAddMessage,
     captureStrategy: cfg.captureStrategy ?? "last_turn",
     maxMessageChars: cfg.maxMessageChars ?? 20000,
     maxItemChars: cfg.maxItemChars ?? 8000,

--- a/moltbot.plugin.json
+++ b/moltbot.plugin.json
@@ -57,6 +57,11 @@
         "type": "boolean",
         "default": true
       },
+      "disableAutoSearchMemory": {
+        "type": "boolean",
+        "description": "Disable the automatic /search/memory call on before_agent_start",
+        "default": false
+      },
       "recallGlobal": {
         "type": "boolean",
         "default": true
@@ -64,6 +69,11 @@
       "addEnabled": {
         "type": "boolean",
         "default": true
+      },
+      "disableAutoAddMessage": {
+        "type": "boolean",
+        "description": "Disable the automatic /add/message call on agent_end",
+        "default": false
       },
       "captureStrategy": {
         "type": "string",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -57,6 +57,11 @@
         "type": "boolean",
         "default": true
       },
+      "disableAutoSearchMemory": {
+        "type": "boolean",
+        "description": "Disable the automatic /search/memory call on before_agent_start",
+        "default": false
+      },
       "recallGlobal": {
         "type": "boolean",
         "default": true
@@ -64,6 +69,11 @@
       "addEnabled": {
         "type": "boolean",
         "default": true
+      },
+      "disableAutoAddMessage": {
+        "type": "boolean",
+        "description": "Disable the automatic /add/message call on agent_end",
+        "default": false
       },
       "captureStrategy": {
         "type": "string",

--- a/test/disable-auto-addmessage.test.mjs
+++ b/test/disable-auto-addmessage.test.mjs
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import plugin from "../index.js";
+import { buildConfig } from "../lib/memos-cloud-api.js";
+
+function createApi(pluginConfig = {}) {
+  const handlers = new Map();
+  return {
+    pluginConfig,
+    config: {},
+    logger: {
+      info() {},
+      warn() {},
+    },
+    on(eventName, handler) {
+      handlers.set(eventName, handler);
+    },
+    registerHook() {},
+    getHandler(eventName) {
+      return handlers.get(eventName);
+    },
+  };
+}
+
+function createEvent() {
+  return {
+    success: true,
+    messages: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "world" },
+    ],
+  };
+}
+
+test("disableAutoAddMessage defaults to false", () => {
+  const cfg = buildConfig({});
+  assert.equal(cfg.disableAutoAddMessage, false);
+});
+
+test("agent_end skips automatic addMessage when disableAutoAddMessage is enabled", async () => {
+  const api = createApi({
+    apiKey: "test-token",
+    baseUrl: "https://example.com",
+    disableAutoAddMessage: true,
+  });
+  plugin.register(api);
+
+  const agentEnd = api.getHandler("agent_end");
+  assert.equal(typeof agentEnd, "function");
+
+  const originalFetch = global.fetch;
+  const calls = [];
+  global.fetch = async (...args) => {
+    calls.push(args);
+    return {
+      ok: true,
+      json: async () => ({ ok: true }),
+    };
+  };
+
+  try {
+    await agentEnd(createEvent(), { sessionKey: "session:disable-auto-add" });
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  assert.equal(calls.length, 0);
+});
+
+test("agent_end still calls addMessage by default", async () => {
+  const api = createApi({
+    apiKey: "test-token",
+    baseUrl: "https://example.com",
+  });
+  plugin.register(api);
+
+  const agentEnd = api.getHandler("agent_end");
+  assert.equal(typeof agentEnd, "function");
+
+  const originalFetch = global.fetch;
+  const calls = [];
+  global.fetch = async (...args) => {
+    calls.push(args);
+    return {
+      ok: true,
+      json: async () => ({ ok: true }),
+    };
+  };
+
+  try {
+    await agentEnd(createEvent(), { sessionKey: "session:default-auto-add" });
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0], "https://example.com/add/message");
+});

--- a/test/disable-auto-search-memory.test.mjs
+++ b/test/disable-auto-search-memory.test.mjs
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import plugin from "../index.js";
+import { buildConfig } from "../lib/memos-cloud-api.js";
+
+function createApi(pluginConfig = {}) {
+  const handlers = new Map();
+  return {
+    pluginConfig,
+    config: {},
+    logger: {
+      info() {},
+      warn() {},
+    },
+    on(eventName, handler) {
+      handlers.set(eventName, handler);
+    },
+    registerHook() {},
+    getHandler(eventName) {
+      return handlers.get(eventName);
+    },
+  };
+}
+
+test("disableAutoSearchMemory defaults to false", () => {
+  const cfg = buildConfig({});
+  assert.equal(cfg.disableAutoSearchMemory, false);
+});
+
+test("before_agent_start skips automatic searchMemory when disableAutoSearchMemory is enabled", async () => {
+  const api = createApi({
+    apiKey: "test-token",
+    baseUrl: "https://example.com",
+    disableAutoSearchMemory: true,
+  });
+  plugin.register(api);
+
+  const beforeAgentStart = api.getHandler("before_agent_start");
+  assert.equal(typeof beforeAgentStart, "function");
+
+  const originalFetch = global.fetch;
+  const calls = [];
+  global.fetch = async (...args) => {
+    calls.push(args);
+    return {
+      ok: true,
+      json: async () => ({ data: null }),
+    };
+  };
+
+  try {
+    await beforeAgentStart({ prompt: "hello" }, { sessionKey: "session:disable-auto-search" });
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  assert.equal(calls.length, 0);
+});
+
+test("before_agent_start still calls searchMemory by default", async () => {
+  const api = createApi({
+    apiKey: "test-token",
+    baseUrl: "https://example.com",
+  });
+  plugin.register(api);
+
+  const beforeAgentStart = api.getHandler("before_agent_start");
+  assert.equal(typeof beforeAgentStart, "function");
+
+  const originalFetch = global.fetch;
+  const calls = [];
+  global.fetch = async (...args) => {
+    calls.push(args);
+    return {
+      ok: true,
+      json: async () => ({ data: null }),
+    };
+  };
+
+  try {
+    await beforeAgentStart({ prompt: "hello" }, { sessionKey: "session:default-auto-search" });
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0], "https://example.com/search/memory");
+});


### PR DESCRIPTION
## What
- add `disableAutoSearchMemory` to skip automatic `/search/memory` on `before_agent_start`
- add `disableAutoAddMessage` to skip automatic `/add/message` on `agent_end`
- update plugin schemas and README docs for both switches
- add tests covering default behavior and disabled behavior

## Verification
- run `node --test`
