### PR TITLE
fix: prefer update time for recall display timestamps

### DIFF
--- a/lib/memos-cloud-api.js
+++ b/lib/memos-cloud-api.js
@@ -518,12 +518,16 @@ function sanitizeInlineText(text) {
   return String(text).replace(/\r?\n+/g, " ").trim();
 }
 
+function resolveDisplayTime(item) {
+  return item?.update_time ?? item?.create_time;
+}
+
 function formatMemoryLine(item, text, options = {}) {
   const cleaned = sanitizeInlineText(text);
   if (!cleaned) return "";
   const maxChars = options.maxItemChars;
   const truncated = truncate(cleaned, maxChars);
-  const time = formatTime(item?.create_time);
+  const time = formatTime(resolveDisplayTime(item));
   if (time) return `   -[${time}] ${truncated}`;
   return `   - ${truncated}`;
 }
@@ -533,7 +537,7 @@ function formatPreferenceLine(item, text, options = {}) {
   if (!cleaned) return "";
   const maxChars = options.maxItemChars;
   const truncated = truncate(cleaned, maxChars);
-  const time = formatTime(item?.create_time);
+  const time = formatTime(resolveDisplayTime(item));
   const type = normalizePreferenceType(item?.preference_type);
   const typeLabel = type ? ` [${type}]` : "";
   if (time) return `   -[${time}]${typeLabel} ${truncated}`;

--- a/test/query-strip.test.mjs
+++ b/test/query-strip.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   USER_QUERY_MARKER,
+  formatPromptBlockFromData,
   sanitizeAddMessagePayload,
   sanitizeSearchPayload,
   stripOpenClawInjectedPrefix,
@@ -337,4 +338,44 @@ test("sanitizes only user messages in add payload", () => {
       },
     ],
   });
+});
+
+test("formatPromptBlockFromData prefers update_time over create_time", () => {
+  const block = formatPromptBlockFromData({
+    memory_detail_list: [
+      {
+        memory_value: "更新后的记忆",
+        create_time: "2026-03-17 10:00",
+        update_time: "2026-03-18 16:20",
+        relativity: 0.9,
+      },
+    ],
+    preference_detail_list: [
+      {
+        preference: "更新后的偏好",
+        preference_type: "explicit",
+        create_time: "2026-03-17 11:00",
+        update_time: "2026-03-18 16:21",
+        relativity: 0.9,
+      },
+    ],
+  });
+
+  assert.match(block, /\-\[2026-03-18 16:20\] 更新后的记忆/);
+  assert.match(block, /\-\[2026-03-18 16:21\] \[Explicit Preference\] 更新后的偏好/);
+});
+
+test("formatPromptBlockFromData falls back to create_time when update_time is missing", () => {
+  const block = formatPromptBlockFromData({
+    memory_detail_list: [
+      {
+        memory_value: "只有创建时间",
+        create_time: "2026-03-18 09:30",
+        relativity: 0.9,
+      },
+    ],
+    preference_detail_list: [],
+  });
+
+  assert.match(block, /\-\[2026-03-18 09:30\] 只有创建时间/);
 });


### PR DESCRIPTION
## Problem

The recall display generated from `searchMemory` results is currently showing `create_time` for memory and preference entries.

That is not ideal for the current product behavior, because these records are mutable and may be edited, merged, or refreshed after their initial creation. In that case, showing `create_time` makes the displayed timestamp look stale even when the record itself was updated more recently.

## Expected behavior

When recall content is rendered into the `<memories>` block for the agent:

- prefer `update_time` when it exists
- fall back to `create_time` when `update_time` is missing

This better reflects the latest effective state of a memory/preference item while remaining backward compatible with older payloads.

## What I verified before changing it

I checked the current `test` branch behavior and confirmed:

1. the display path was still using `create_time`
2. the current MemOS `/search/memory` response already returns both `create_time` and `update_time`

So this is not a schema guess or speculative change; it aligns the display logic with fields that are already present in the live API response.

## Solution

This PR introduces a very small display-layer adjustment:

- add a shared `resolveDisplayTime(item)` helper
- use `item.update_time ?? item.create_time` for rendered memory timestamps
- apply the same logic to both:
  - memory facts
  - preference lines

The change is intentionally limited to recall rendering only.
It does **not** change search ranking, storage behavior, or any write-path semantics.

## Why this is safer than changing other layers

The issue here is presentation semantics, not data semantics.
So the fix stays in the formatting layer instead of changing:

- backend ordering
- retrieval scoring
- persistence fields
- API contracts

This keeps the change minimal and easy to review.

## Tests

Ran:

```bash
node --test
```

Result:

- 29 passed
- 0 failed

Added regression coverage for:

1. preferring `update_time` over `create_time`
2. falling back to `create_time` when `update_time` is absent

## Files changed

- `lib/memos-cloud-api.js`
- `test/query-strip.test.mjs`

## Outcome

After this PR, recall snippets shown to the agent use the more meaningful timestamp for mutable records, while preserving compatibility with older data that only has `create_time`.
