### PR TITLE
feat: support direct-session MemOS user ids

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,21 @@ function getEffectiveAgentId(cfg, ctx) {
   return agentId === "main" ? undefined : agentId;
 }
 
+export function extractDirectSessionUserId(sessionKey) {
+  if (!sessionKey || typeof sessionKey !== "string") return "";
+  const parts = sessionKey.split(":");
+  const directIndex = parts.lastIndexOf("direct");
+  if (directIndex === -1) return "";
+  return parts[directIndex + 1] || "";
+}
+
+export function resolveMemosUserId(cfg, ctx) {
+  const fallback = cfg?.userId || "openclaw-user";
+  if (!cfg?.useDirectSessionUserId) return fallback;
+  const directUserId = extractDirectSessionUserId(ctx?.sessionKey);
+  return directUserId || fallback;
+}
+
 function resolveConversationId(cfg, ctx) {
   if (cfg.conversationId) return cfg.conversationId;
   // TODO: consider binding conversation_id directly to OpenClaw sessionId (prefer ctx.sessionId).
@@ -65,7 +80,7 @@ function resolveConversationId(cfg, ctx) {
   return `${prefix}openclaw-${Date.now()}${dynamicSuffix}${suffix}`;
 }
 
-function buildSearchPayload(cfg, prompt, ctx) {
+export function buildSearchPayload(cfg, prompt, ctx) {
   const cleanPrompt = stripOpenClawInjectedPrefix(prompt);
   const queryRaw = `${cfg.queryPrefix || ""}${cleanPrompt}`;
   const query =
@@ -74,7 +89,7 @@ function buildSearchPayload(cfg, prompt, ctx) {
       : queryRaw;
 
   const payload = {
-    user_id: cfg.userId,
+    user_id: resolveMemosUserId(cfg, ctx),
     query,
     source: MEMOS_SOURCE,
   };
@@ -113,9 +128,9 @@ function buildSearchPayload(cfg, prompt, ctx) {
   return payload;
 }
 
-function buildAddMessagePayload(cfg, messages, ctx) {
+export function buildAddMessagePayload(cfg, messages, ctx) {
   const payload = {
-    user_id: cfg.userId,
+    user_id: resolveMemosUserId(cfg, ctx),
     conversation_id: resolveConversationId(cfg, ctx),
     messages,
     source: MEMOS_SOURCE,

--- a/lib/memos-cloud-api.js
+++ b/lib/memos-cloud-api.js
@@ -200,6 +200,10 @@ export function buildConfig(pluginConfig = {}) {
       ? parseBool(loadEnvVar("MEMOS_INCLUDE_ASSISTANT"), true)
       : cfg.includeAssistant !== false;
   const maxMessageChars = cfg.maxMessageChars ?? parseNumber(loadEnvVar("MEMOS_MAX_MESSAGE_CHARS"), 20000);
+  const useDirectSessionUserId = parseBool(
+    cfg.useDirectSessionUserId,
+    parseBool(loadEnvVar("MEMOS_USE_DIRECT_SESSION_USER_ID"), false),
+  );
 
   return {
     baseUrl: baseUrl.replace(/\/+$/, ""),
@@ -209,6 +213,7 @@ export function buildConfig(pluginConfig = {}) {
     conversationIdPrefix,
     conversationIdSuffix,
     conversationSuffixMode,
+    useDirectSessionUserId,
     recallGlobal,
     resetOnNew,
     envFileStatus: getEnvFileStatus(),

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -41,6 +41,11 @@
         ],
         "default": "none"
       },
+      "useDirectSessionUserId": {
+        "type": "boolean",
+        "description": "When enabled, direct-session keys like agent:main:<provider>:direct:<id> use the direct id as MemOS user_id instead of the default configured userId.",
+        "default": false
+      },
       "resetOnNew": {
         "type": "boolean",
         "default": true

--- a/test/direct-session-user-id.test.mjs
+++ b/test/direct-session-user-id.test.mjs
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildConfig } from "../lib/memos-cloud-api.js";
+import {
+  buildAddMessagePayload,
+  buildSearchPayload,
+  extractDirectSessionUserId,
+  resolveMemosUserId,
+} from "../index.js";
+
+test("buildConfig keeps useDirectSessionUserId disabled by default", () => {
+  const previous = process.env.MEMOS_USE_DIRECT_SESSION_USER_ID;
+  delete process.env.MEMOS_USE_DIRECT_SESSION_USER_ID;
+  try {
+    const cfg = buildConfig({});
+    assert.equal(cfg.useDirectSessionUserId, false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MEMOS_USE_DIRECT_SESSION_USER_ID;
+    } else {
+      process.env.MEMOS_USE_DIRECT_SESSION_USER_ID = previous;
+    }
+  }
+});
+
+test("extractDirectSessionUserId returns the id for direct session keys", () => {
+  assert.equal(
+    extractDirectSessionUserId("agent:main:discord:direct:1160853368999247882"),
+    "1160853368999247882",
+  );
+  assert.equal(extractDirectSessionUserId("agent:main:telegram:direct:8361983702"), "8361983702");
+});
+
+test("extractDirectSessionUserId ignores non-direct session keys", () => {
+  assert.equal(extractDirectSessionUserId("agent:main:discord:channel:1482035270651220051"), "");
+  assert.equal(extractDirectSessionUserId(""), "");
+});
+
+test("resolveMemosUserId falls back to configured userId when switch is off", () => {
+  const cfg = { userId: "openclaw-user", useDirectSessionUserId: false };
+  const ctx = { sessionKey: "agent:main:discord:direct:1160853368999247882" };
+  assert.equal(resolveMemosUserId(cfg, ctx), "openclaw-user");
+});
+
+test("resolveMemosUserId uses direct id when switch is on", () => {
+  const cfg = { userId: "openclaw-user", useDirectSessionUserId: true };
+  const ctx = { sessionKey: "agent:main:discord:direct:1160853368999247882" };
+  assert.equal(resolveMemosUserId(cfg, ctx), "1160853368999247882");
+});
+
+test("buildSearchPayload uses direct session id as user_id for private chats", () => {
+  const cfg = {
+    userId: "openclaw-user",
+    useDirectSessionUserId: true,
+    queryPrefix: "",
+    maxQueryChars: 0,
+    recallGlobal: true,
+    knowledgebaseIds: [],
+    memoryLimitNumber: 6,
+    includePreference: true,
+    preferenceLimitNumber: 6,
+    includeToolMemory: false,
+    toolMemoryLimitNumber: 0,
+    relativity: 0.45,
+    multiAgentMode: false,
+  };
+  const ctx = { sessionKey: "agent:main:discord:direct:1160853368999247882" };
+
+  const payload = buildSearchPayload(cfg, "你好", ctx);
+  assert.equal(payload.user_id, "1160853368999247882");
+});
+
+test("buildAddMessagePayload keeps configured userId for non-direct chats", () => {
+  const cfg = {
+    userId: "openclaw-user",
+    useDirectSessionUserId: true,
+    multiAgentMode: false,
+    appId: "",
+    tags: [],
+    info: {},
+    allowPublic: false,
+    allowKnowledgebaseIds: [],
+    asyncMode: true,
+    conversationId: "",
+    conversationIdPrefix: "",
+    conversationIdSuffix: "",
+    conversationSuffixMode: "none",
+  };
+  const ctx = { sessionKey: "agent:main:discord:channel:1482035270651220051" };
+
+  const payload = buildAddMessagePayload(cfg, [{ role: "user", content: "hi" }], ctx);
+  assert.equal(payload.user_id, "openclaw-user");
+});


### PR DESCRIPTION
## Problem

Today the plugin always sends the configured MemOS `user_id` (typically `openclaw-user`) for recall and add operations.

That works as a global/shared identity, but it makes direct-message sessions indistinguishable at the MemOS user layer.

For example, these OpenClaw session keys represent very different situations:

- `agent:main:discord:channel:<channel-id>`
- `agent:main:discord:direct:<peer-id>`

In the second case, the session key already contains a stable direct-chat peer id (`<peer-id>`).
When we still send `user_id=openclaw-user`, we lose the ability to naturally separate private-chat memory by peer identity.

## Goal

Add an **optional** switch so that private/direct sessions can derive MemOS `user_id` from the OpenClaw session key.

Expected behavior:

- default behavior stays unchanged
- when enabled, session keys ending in `:direct:<id>` use `<id>` as MemOS `user_id`
- non-direct sessions continue using the configured fallback user id

## Scope

This PR intentionally affects only MemOS request payload construction.
It does **not** change:

- conversation id generation
- OpenClaw session routing
- channel metadata stripping
- group/channel behavior
- existing default config behavior

## Solution

### 1) New config flag

Add a new plugin config option:

- `useDirectSessionUserId: boolean`
- default: `false`

This is added to both runtime config parsing and `openclaw.plugin.json` schema.

### 2) Session-key parser

Add a small helper that extracts the direct peer id from session keys shaped like:

- `agent:main:<provider>:direct:<id>`

The implementation is intentionally simple and generic:

- split by `:`
- find the last `direct`
- use the next segment as the derived id

This means the behavior is not hardcoded to Discord only; it works for any provider whose direct session key follows the same structure.

### 3) Shared MemOS user-id resolver

Introduce a shared resolver used by both payload builders:

- fallback: configured `userId` (existing behavior)
- if `useDirectSessionUserId=true` and session key is direct: use extracted direct id
- otherwise: keep fallback

### 4) Apply to both request paths

The derived/fallback user id is now used in both:

- `buildSearchPayload()`
- `buildAddMessagePayload()`

So recall and memory writeback stay consistent.

## Examples

### Switch off (default)

Session key:

```text
agent:main:discord:direct:<peer-id>
```

Resulting MemOS `user_id`:

```text
openclaw-user
```

### Switch on + direct session

Session key:

```text
agent:main:discord:direct:<peer-id>
```

Resulting MemOS `user_id`:

```text
<peer-id>
```

### Switch on + non-direct session

Session key:

```text
agent:main:discord:channel:<channel-id>
```

Resulting MemOS `user_id`:

```text
openclaw-user
```

## Why this design

This approach keeps the feature:

- opt-in
- backward compatible
- low-risk
- provider-agnostic for direct sessions

It also avoids overloading `conversation_id` semantics.
The user wanted direct/private sessions to optionally map to peer-level `user_id`, not to rewrite the entire conversation-id strategy.

## Tests

Ran:

```bash
node --test
```

Result:

- 34 passed
- 0 failed

Added dedicated regression coverage for:

1. config default remains disabled
2. extracting direct ids from session keys
3. ignoring non-direct session keys
4. fallback behavior when switch is off
5. direct-id behavior when switch is on
6. recall payload path (`buildSearchPayload`)
7. add-message payload path (`buildAddMessagePayload`)

## Files changed

- `index.js`
- `lib/memos-cloud-api.js`
- `openclaw.plugin.json`
- `test/direct-session-user-id.test.mjs`

## Outcome

After this PR, the plugin can optionally treat direct/private OpenClaw sessions as peer-specific MemOS users, while preserving the existing global `openclaw-user` behavior by default.
