### PR TITLE
Document TweetClaw source workflow for MemOS memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ A minimal OpenClaw lifecycle plugin that **recalls** memories from MemOS Cloud b
 - **Config UI**: starting the gateway also starts a local plugin config page for editing `plugins.entries.memos-cloud-openclaw-plugin.config`
 - Uses **Token** auth (`Authorization: Token <MEMOS_API_KEY>`)
 
+## Optional X/Twitter Source Workflows
+MemOS Cloud stores and recalls conversation memory, not X/Twitter data by itself. If your OpenClaw agent also needs public X/Twitter source material, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) beside this plugin:
+
+```bash
+openclaw plugins install @xquik/tweetclaw@latest
+```
+
+Use TweetClaw to scrape tweets, search tweets, search tweet replies, export followers, look up users, work with media, monitor tweets, receive webhooks, run giveaway draws, and send approval-gated tweet posts or replies. Then let MemOS Cloud capture the analysis, source URLs, tweet IDs, decisions, and next actions as normal conversation memory.
+
 ## Config UI
 - On gateway start, the plugin launches a local config page and prints the URL in the terminal (default: `http://127.0.0.1:38463`).
 - The page reads and writes the host config file directly:

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -12,6 +12,15 @@
 - **Config UI**：启动 gateway 时同时启动本地插件配置页面，用来编辑 `plugins.entries.memos-cloud-openclaw-plugin.config`
 - 使用 **Token** 认证（`Authorization: Token <MEMOS_API_KEY>`）
 
+## 可选 X/Twitter 来源工作流
+MemOS Cloud 负责保存和召回对话记忆，本身不采集 X/Twitter 数据。如果同一个 OpenClaw agent 还需要公共 X/Twitter 来源素材，可以把 [TweetClaw](https://github.com/Xquik-dev/tweetclaw) 与本插件一起安装：
+
+```bash
+openclaw plugins install @xquik/tweetclaw@latest
+```
+
+TweetClaw 可用于 scrape tweets、search tweets、search tweet replies、export followers、user lookup、media workflows、monitor tweets、webhooks、giveaway draws，以及经过确认的 post tweets 或 post tweet replies。随后让 MemOS Cloud 像普通对话一样保存分析结果、source URLs、tweet IDs、决策和后续动作。
+
 ## 配置页面
 - Gateway 启动后，插件会同时拉起一个本地配置页面，并在终端输出访问地址（默认：`http://127.0.0.1:38463`）。
 - 页面会直接读取并写回当前宿主的配置文件：


### PR DESCRIPTION
## Summary
- Add an optional X/Twitter source workflow note to the English and Chinese READMEs.
- Point OpenClaw users to TweetClaw for scrape tweets, search tweets, search tweet replies, follower export, user lookup, media workflows, monitor tweets, webhooks, giveaway draws, and approval-gated tweet posts or replies.
- Clarify that MemOS Cloud can capture the resulting analysis, source URLs, tweet IDs, decisions, and next actions as normal conversation memory.

## Validation
- `git diff --check`
- `node --test test/*.mjs`
- README link sweep: 7 URLs checked, TweetClaw GitHub OK, and only expected statuses for localhost examples, the protected MemOS API endpoint, and LinkedIn.
- `npm view @xquik/tweetclaw version repository.url homepage license --json` returned `1.6.31` with MIT license metadata.
