### PR TITLE
ci: automate OpenClaw cloud plugin releases

### DIFF
--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -120,9 +120,13 @@ function readJsonFile(path) {
 }
 
 function tagInfo(ref) {
-  const text = git(["show", "--no-patch", "--format=%H%n%ci%n%s", `${ref}^{commit}`]);
+  const text = git(["show", "--no-patch", "--format=%H%n%ci%n%s", commitRef(ref)]);
   const [sha = "", date = "", subject = ""] = text.split("\n");
   return { tag: ref, sha, date, subject };
+}
+
+function commitRef(ref) {
+  return `${ref}^{commit}`;
 }
 
 function refInfo(ref, tagLabel) {
@@ -317,7 +321,7 @@ export function collectEvidence({ targetVersion, currentTag, previousTag, curren
     current_ref: currentRef,
     diff_range: diffRange,
     target_version: displayVersion(targetVersion),
-    git_ref: git(["rev-parse", "--short=12", currentRef]),
+    git_ref: git(["rev-parse", "--short=12", commitRef(currentRef)]),
     previous: tagInfo(previousTag),
     current: refInfo(currentRef, currentTag),
     commits,

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -120,7 +120,7 @@ function readJsonFile(path) {
 }
 
 function tagInfo(ref) {
-  const text = git(["show", "--no-patch", "--format=%H%n%ci%n%s", ref]);
+  const text = git(["show", "--no-patch", "--format=%H%n%ci%n%s", `${ref}^{commit}`]);
   const [sha = "", date = "", subject = ""] = text.split("\n");
   return { tag: ref, sha, date, subject };
 }

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -1,0 +1,1215 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
+
+export const PRODUCT_ID = "openclaw-cloud-plugin";
+export const PRODUCT_TITLE = {
+  zh: "OpenClaw 云插件",
+  en: "OpenClaw Cloud Plugin",
+};
+export const RELEASE_NOTE_GUIDANCE = {
+  category_policy: {
+    Added:
+      "Use for newly exposed user-facing capabilities, configuration entries, lifecycle hooks, agent integrations, or memory workflow modes.",
+    Improved:
+      "Use for recall/add-memory quality, prompt sanitization, session or user-id resolution, telemetry hardening, packaging, compatibility, or reliability improvements when the evidence is not primarily a broken-behavior fix.",
+    Fixed:
+      "Use for concrete broken behavior, regressions, auth or endpoint handling bugs, duplicate prompt injection, failed retries, or configuration that existed but did not take effect.",
+  },
+  quality_policy: [
+    "Prefer Added / Improved / Fixed sections when the evidence supports all three; omit a section only when evidence is insufficient.",
+    "Keep bullets short, product-facing, and evidence-backed; do not mention internal file names unless they are the feature name users recognize.",
+    "Do not collapse newly added capability and a bug fix in the same subsystem into one item when both are separately evidenced.",
+    "Do not describe release automation, tests, or packaging as a user-facing plugin capability unless the evidence changes the published plugin behavior.",
+  ],
+  translation_policy: [
+    "Treat text_cn as the canonical release-note wording first, then translate text_cn into text_en.",
+    "Do not independently invent English facts beyond the Chinese canonical bullet and its source_refs.",
+    "Keep category and source_refs identical between Chinese and English outputs.",
+    "text_cn must contain Chinese text; text_en must not contain Chinese/CJK characters.",
+  ],
+};
+
+const REPOSITORY = "MemTensor/MemOS-Cloud-OpenClaw-Plugin";
+const CURRENT_TAG_PREFIX = "v";
+const RELEASE_NOTES_MARKER = "doc-agent-release-notes-json";
+const RELEASE_CATEGORY_ORDER = ["Added", "Improved", "Fixed"];
+const MAX_DRAFT_REPAIR_ATTEMPTS = 2;
+const RELEASE_TO_DOC_CATEGORY = {
+  Added: "New Features",
+  Improved: "Improvements",
+  Fixed: "Bug Fixes",
+};
+const CJK_RE = /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff]/;
+
+function fail(message) {
+  throw new Error(String(message));
+}
+
+function warn(message) {
+  console.error(`::warning::${message}`);
+}
+
+function git(args, options = {}) {
+  return execFileSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  }).trim();
+}
+
+export function cleanVersion(raw) {
+  const value = String(raw || "").trim();
+  return value.startsWith("v") ? value.slice(1) : value;
+}
+
+export function displayVersion(raw) {
+  const value = cleanVersion(raw);
+  return value ? `v${value}` : "";
+}
+
+export function versionFromTag(tag) {
+  const value = String(tag || "").trim();
+  if (!value.startsWith(CURRENT_TAG_PREFIX)) return "";
+  return cleanVersion(value.slice(CURRENT_TAG_PREFIX.length));
+}
+
+export function parseSemver(version) {
+  const cleaned = cleanVersion(version);
+  const match = cleaned.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+]([0-9A-Za-z.-]+))?$/);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] || "",
+  };
+}
+
+export function compareSemver(a, b) {
+  const av = parseSemver(a);
+  const bv = parseSemver(b);
+  if (!av || !bv) return String(a).localeCompare(String(b));
+  for (const key of ["major", "minor", "patch"]) {
+    if (av[key] !== bv[key]) return av[key] - bv[key];
+  }
+  if (av.prerelease === bv.prerelease) return 0;
+  if (!av.prerelease) return 1;
+  if (!bv.prerelease) return -1;
+  return av.prerelease.localeCompare(bv.prerelease);
+}
+
+function gitShowJson(ref, path) {
+  try {
+    return JSON.parse(git(["show", `${ref}:${path}`]));
+  } catch {
+    return {};
+  }
+}
+
+function readJsonFile(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function tagInfo(ref) {
+  const text = git(["show", "--no-patch", "--format=%H%n%ci%n%s", ref]);
+  const [sha = "", date = "", subject = ""] = text.split("\n");
+  return { tag: ref, sha, date, subject };
+}
+
+function refInfo(ref, tagLabel) {
+  const info = tagInfo(ref);
+  return { ...info, tag: tagLabel || ref, ref };
+}
+
+function refExists(ref) {
+  try {
+    git(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveCurrentRef(
+  currentTag,
+  { requestedRef = process.env.RELEASE_EVIDENCE_REF || "", refExistsImpl = refExists } = {},
+) {
+  const explicit = String(requestedRef || "").trim();
+  if (explicit) {
+    if (!refExistsImpl(explicit)) {
+      fail(`RELEASE_EVIDENCE_REF does not exist or is not a commit: ${explicit}`);
+    }
+    return explicit;
+  }
+  if (currentTag && refExistsImpl(currentTag)) return currentTag;
+  return "HEAD";
+}
+
+function listProductTags() {
+  try {
+    git(["fetch", "--tags", "--force", "origin"], { stdio: ["ignore", "ignore", "ignore"] });
+  } catch {
+    warn("Failed to fetch tags from origin; using locally available tags.");
+  }
+
+  return git(["tag", "--list", "v*"])
+    .split("\n")
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .map((tag) => ({ tag, version: versionFromTag(tag) }))
+    .filter((item) => item.version && parseSemver(item.version));
+}
+
+export function findPreviousTag(targetVersion, currentTag) {
+  const candidates = listProductTags()
+    .filter((item) => item.tag !== currentTag)
+    .filter((item) => compareSemver(item.version, targetVersion) < 0)
+    .sort((a, b) => compareSemver(b.version, a.version));
+  return candidates[0]?.tag || "";
+}
+
+function parseCommits(previousTag, currentRef) {
+  const text = git(["log", "--format=%H%x09%h%x09%s", "--no-merges", `${previousTag}..${currentRef}`]);
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [sha = "", shortSha = "", subject = ""] = line.split("\t");
+      return { sha, short_sha: shortSha, subject };
+    });
+}
+
+function parseChangedFiles(previousTag, currentRef) {
+  const text = git(["diff", "--name-status", `${previousTag}..${currentRef}`]);
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split("\t");
+      const item = { status: parts[0], path: parts[parts.length - 1] };
+      if (parts.length === 3) item.old_path = parts[1];
+      return item;
+    });
+}
+
+function packageChanges(previousTag, currentRef) {
+  const before = gitShowJson(previousTag, "package.json");
+  const after = currentRef === "HEAD" ? readJsonFile("package.json") : gitShowJson(currentRef, "package.json");
+  return ["name", "version"]
+    .filter((field) => before[field] !== after[field])
+    .map((field) => ({ field, before: before[field], after: after[field] }));
+}
+
+function extractPullRequests(commits, repo = process.env.GITHUB_REPOSITORY || REPOSITORY) {
+  const seen = new Set();
+  for (const commit of commits) {
+    for (const match of String(commit.subject || "").matchAll(/#(\d+)/g)) {
+      seen.add(match[1]);
+    }
+  }
+  return [...seen].map((number) => ({
+    number,
+    url: `https://github.com/${repo}/pull/${number}`,
+  }));
+}
+
+function refsForGuidance(commit) {
+  const refs = [];
+  if (commit.short_sha) refs.push(commit.short_sha);
+  for (const match of String(commit.subject || "").matchAll(/#(\d+)/g)) {
+    const value = `#${match[1]}`;
+    if (!refs.includes(value)) refs.push(value);
+  }
+  return refs;
+}
+
+function categoryHintForSubject(subject) {
+  const value = String(subject || "");
+  const lower = value.toLowerCase();
+  if (
+    lower.startsWith("release:") ||
+    /^chore(\([^)]+\))?:\s*(release|version|bump)\b/i.test(value) ||
+    /^test(\([^)]+\))?:/i.test(value) ||
+    /^docs(\([^)]+\))?:/i.test(value)
+  ) {
+    return null;
+  }
+  if (/^(feat|feature|add)(\([^)]+\))?:|^add\s+/i.test(value)) {
+    return {
+      category: "Added",
+      reason: "new user-facing cloud plugin capability, configuration, or lifecycle support",
+    };
+  }
+  if (/^(perf|performance|refactor|improve|enhance)(\([^)]+\))?:/i.test(value)) {
+    return {
+      category: "Improved",
+      reason: "performance, maintainability, compatibility, or reliability improvement",
+    };
+  }
+  if (
+    /recall filter|prompt|sanitize|query strip|session|user[-_ ]?id|hook|registration|telemetry|rum|pack|publish|sync-version/i.test(
+      value,
+    ) &&
+    !/^(fix|hotfix|bugfix)(\([^)]+\))?:|^fix\s+#\d+/i.test(value)
+  ) {
+    return {
+      category: "Improved",
+      reason: "cloud plugin integration, prompt, packaging, or telemetry robustness improvement",
+    };
+  }
+  if (/^(fix|hotfix|bugfix)(\([^)]+\))?:|^fix\s+#\d+/i.test(value)) {
+    return {
+      category: "Fixed",
+      reason: "specific cloud plugin bug fix",
+    };
+  }
+  return null;
+}
+
+export function categoryHintsForCommits(commits) {
+  return commits
+    .map((commit) => {
+      const hint = categoryHintForSubject(commit.subject);
+      const sourceRefs = refsForGuidance(commit);
+      if (!hint || sourceRefs.length === 0) return null;
+      return {
+        ...hint,
+        source_refs: sourceRefs,
+        subject: commit.subject,
+      };
+    })
+    .filter(Boolean);
+}
+
+export function releaseNoteGuidanceForCommits(commits) {
+  return {
+    ...RELEASE_NOTE_GUIDANCE,
+    source_ref_category_hints: categoryHintsForCommits(commits),
+    source_ref_hint_policy:
+      "Treat source_ref_category_hints as advisory classification hints grounded in evidence. " +
+      "Use them to cover important feat/fix/perf/refactor commits without inventing product facts.",
+  };
+}
+
+export function collectEvidence({ targetVersion, currentTag, previousTag, currentRef = "HEAD" }) {
+  const commits = parseCommits(previousTag, currentRef);
+  const changedFiles = parseChangedFiles(previousTag, currentRef);
+  const diffRange = `${previousTag}..${currentRef}`;
+  const repo = process.env.GITHUB_REPOSITORY || REPOSITORY;
+  const importantDiff = git(["diff", "--unified=2", diffRange]).slice(0, 24000);
+
+  return {
+    product_id: PRODUCT_ID,
+    product_title: PRODUCT_TITLE,
+    release_note_guidance: releaseNoteGuidanceForCommits(commits),
+    repo,
+    previous_tag: previousTag,
+    current_tag: currentTag,
+    current_ref: currentRef,
+    diff_range: diffRange,
+    target_version: displayVersion(targetVersion),
+    git_ref: git(["rev-parse", "--short=12", currentRef]),
+    previous: tagInfo(previousTag),
+    current: refInfo(currentRef, currentTag),
+    commits,
+    pull_requests: extractPullRequests(commits, repo),
+    changed_files: changedFiles,
+    diff_stat: git(["diff", "--stat", diffRange]),
+    important_diff: {
+      "openclaw-cloud-plugin/**": importantDiff,
+    },
+    package_changes: packageChanges(previousTag, currentRef),
+    test_changes: changedFiles.filter((item) => item.path.startsWith("test/")),
+    docs_changes: changedFiles.filter((item) => /(^|\/)(README|docs)/i.test(item.path)),
+  };
+}
+
+export function evidenceForInspection(evidence) {
+  const guidance = evidence?.release_note_guidance || {};
+  const {
+    release_note_guidance: _releaseNoteGuidance,
+    important_diff: _importantDiff,
+    ...publicEvidence
+  } = evidence || {};
+  return {
+    ...publicEvidence,
+    release_note_guidance: {
+      source_ref_category_hints: Array.isArray(guidance.source_ref_category_hints)
+        ? guidance.source_ref_category_hints
+        : [],
+    },
+    redactions: {
+      important_diff: "omitted from public workflow artifacts; sent only to the configured draft service",
+      release_note_prompt_guidance: "omitted from public workflow artifacts",
+    },
+  };
+}
+
+export function draftForInspection(draft) {
+  return {
+    ok: Boolean(draft?.ok),
+    needs_review: Boolean(draft?.needs_review),
+    confidence: draft?.confidence || "",
+    release_items: Array.isArray(draft?.release_items) ? draft.release_items : [],
+    coverage: {
+      needs_review: Boolean(draft?.coverage?.needs_review),
+      required_count: Number(draft?.coverage?.required_count || 0),
+      covered_required_count: Number(draft?.coverage?.covered_required_count || 0),
+      missing_required_count: Number(draft?.coverage?.missing_required_count || 0),
+      covered_refs: Array.isArray(draft?.coverage?.covered_refs) ? draft.coverage.covered_refs : [],
+      missing_required: Array.isArray(draft?.coverage?.missing_required) ? draft.coverage.missing_required : [],
+      invalid_item_refs: Array.isArray(draft?.coverage?.invalid_item_refs) ? draft.coverage.invalid_item_refs : [],
+    },
+    warnings: Array.isArray(draft?.warnings) ? draft.warnings : [],
+    language_issues: Array.isArray(draft?.language_issues) ? draft.language_issues : [],
+    postprocess: draft?.postprocess || {},
+    validation_report: draft?.validation_report || {},
+    validation_attempt_count: Number(draft?.validation_attempt_count || 0),
+    repair_attempt_count: Number(draft?.repair_attempt_count || 0),
+    repair_attempts: Array.isArray(draft?.repair_attempts) ? draft.repair_attempts : [],
+    redactions: {
+      server_debug_fields: "omitted from public workflow artifacts",
+      model_and_prompt_details: "omitted from public workflow artifacts",
+    },
+  };
+}
+
+function appendOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  writeFileSync(outputPath, `${name}<<__DOC_AGENT_EOF__\n${value}\n__DOC_AGENT_EOF__\n`, {
+    flag: "a",
+  });
+}
+
+export function ensureSourceHint(notes) {
+  const hint = `<!-- doc-agent: source-id=${PRODUCT_ID} -->`;
+  return notes.includes("doc-agent: source-id=") ? notes : `${notes.trim()}\n\n${hint}\n`;
+}
+
+function normalizeReleaseCategory(value) {
+  const text = String(value || "").trim();
+  return RELEASE_CATEGORY_ORDER.includes(text) ? text : "";
+}
+
+function normalizeSourceRef(value) {
+  const text = String(value || "").trim().replace(/^[`[(\s]+|[`)\],.;\s]+$/g, "");
+  if (/^\d{2,}$/.test(text)) return `#${text}`;
+  if (/^#\d+$/.test(text)) return text;
+  if (/^[a-fA-F0-9]{7,40}$/.test(text)) return text.toLowerCase();
+  return "";
+}
+
+function normalizeSourceRefs(raw) {
+  const values = Array.isArray(raw) ? raw : String(raw || "").match(/#\d+|[a-fA-F0-9]{7,40}/g) || [];
+  const refs = [];
+  for (const value of values) {
+    const ref = normalizeSourceRef(value);
+    if (ref && !refs.includes(ref)) refs.push(ref);
+  }
+  return refs;
+}
+
+function refsForCommit(commit) {
+  const refs = [];
+  for (const ref of [commit?.short_sha, commit?.sha]) {
+    const normalized = normalizeSourceRef(ref);
+    if (normalized && !refs.includes(normalized)) refs.push(normalized);
+  }
+  for (const match of String(commit?.subject || "").matchAll(/#(\d+)/g)) {
+    const ref = `#${match[1]}`;
+    if (!refs.includes(ref)) refs.push(ref);
+  }
+  return refs;
+}
+
+function normalizeReleaseItem(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const category = normalizeReleaseCategory(raw.category);
+  const textCn = String(raw.text_cn || "").trim().replace(/^-+\s*/, "");
+  const textEn = String(raw.text_en || "").trim().replace(/^-+\s*/, "");
+  const sourceRefs = normalizeSourceRefs(raw.source_refs);
+  if (!category || !textCn || !textEn || sourceRefs.length === 0) return null;
+  return {
+    category,
+    text_cn: textCn,
+    text_en: textEn,
+    source_refs: sourceRefs,
+  };
+}
+
+function buildSourceRefIndex(evidence) {
+  const refToGroup = new Map();
+  const groups = new Map();
+  const knownRefs = new Set();
+
+  for (const commit of evidence?.commits || []) {
+    for (const ref of refsForCommit(commit)) knownRefs.add(ref);
+  }
+
+  for (const hint of evidence?.release_note_guidance?.source_ref_category_hints || []) {
+    const refs = normalizeSourceRefs(hint.source_refs);
+    const category = normalizeReleaseCategory(hint.category);
+    if (refs.length === 0 || !category) continue;
+    const groupKey = refs[0];
+    for (const ref of refs) {
+      knownRefs.add(ref);
+      refToGroup.set(ref, groupKey);
+    }
+    groups.set(groupKey, {
+      key: groupKey,
+      category,
+      refs,
+      subject: String(hint.subject || ""),
+      reason: String(hint.reason || ""),
+    });
+  }
+
+  return { refToGroup, groups, knownRefs };
+}
+
+function groupKeyForRef(ref, refToGroup) {
+  return refToGroup.get(ref) || ref;
+}
+
+function groupKeysForItem(item, refToGroup) {
+  const keys = [];
+  for (const ref of item.source_refs || []) {
+    const key = groupKeyForRef(ref, refToGroup);
+    if (!keys.includes(key)) keys.push(key);
+  }
+  return keys;
+}
+
+function bestHintCategoryForItem(item, index) {
+  const categories = [];
+  for (const key of groupKeysForItem(item, index.refToGroup)) {
+    const category = index.groups.get(key)?.category;
+    if (category && !categories.includes(category)) categories.push(category);
+  }
+  if (categories.length === 1) return categories[0];
+  return "";
+}
+
+function scoreOwnerCandidate(item, group, sourceGroupCount, order) {
+  let score = 0;
+  if (item.category === group.category) score += 100;
+  if (sourceGroupCount === 1) score += 20;
+  score -= sourceGroupCount;
+  score -= order / 1000;
+  return score;
+}
+
+function dedupeSourceRefsByBestCategory(items, index) {
+  const candidatesByGroup = new Map();
+  for (const [order, item] of items.entries()) {
+    for (const groupKey of groupKeysForItem(item, index.refToGroup)) {
+      const group = index.groups.get(groupKey);
+      if (!group) continue;
+      const sourceGroupCount = groupKeysForItem(item, index.refToGroup).length;
+      const candidates = candidatesByGroup.get(groupKey) || [];
+      candidates.push({ item, order, sourceGroupCount });
+      candidatesByGroup.set(groupKey, candidates);
+    }
+  }
+
+  const ownerByGroup = new Map();
+  for (const [groupKey, candidates] of candidatesByGroup.entries()) {
+    const group = index.groups.get(groupKey);
+    if (!group) continue;
+    const sorted = [...candidates].sort((a, b) => {
+      const scoreDelta =
+        scoreOwnerCandidate(b.item, group, b.sourceGroupCount, b.order) -
+        scoreOwnerCandidate(a.item, group, a.sourceGroupCount, a.order);
+      return scoreDelta || a.order - b.order;
+    });
+    ownerByGroup.set(groupKey, sorted[0].item);
+  }
+
+  let removedDuplicateRefs = 0;
+  let droppedItems = 0;
+  const filtered = [];
+  for (const item of items) {
+    const refs = [];
+    for (const ref of item.source_refs) {
+      const groupKey = groupKeyForRef(ref, index.refToGroup);
+      const owner = ownerByGroup.get(groupKey);
+      if (!owner || owner === item) {
+        if (!refs.includes(ref)) refs.push(ref);
+      } else {
+        removedDuplicateRefs += 1;
+      }
+    }
+    if (refs.length === 0) {
+      droppedItems += 1;
+      continue;
+    }
+    filtered.push({ ...item, source_refs: refs });
+  }
+  return { items: filtered, removedDuplicateRefs, droppedItems };
+}
+
+function dedupeReleaseItems(items) {
+  const byKey = new Map();
+  for (const item of items) {
+    const key = `${item.category}\n${item.text_cn}\n${item.text_en}`;
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, { ...item, source_refs: [...item.source_refs] });
+      continue;
+    }
+    for (const ref of item.source_refs) {
+      if (!existing.source_refs.includes(ref)) existing.source_refs.push(ref);
+    }
+  }
+  return [...byKey.values()];
+}
+
+function categoriesFromReleaseItems(items) {
+  const releaseCategories = {};
+  const docsCategories = { cn: {}, en: {} };
+  for (const category of RELEASE_CATEGORY_ORDER) {
+    const categoryItems = items.filter((item) => item.category === category);
+    if (categoryItems.length === 0) continue;
+    releaseCategories[category] = categoryItems.map((item) => item.text_cn);
+    const docCategory = RELEASE_TO_DOC_CATEGORY[category];
+    docsCategories.cn[docCategory] = categoryItems.map((item) => item.text_cn);
+    docsCategories.en[docCategory] = categoryItems.map((item) => item.text_en);
+  }
+  return { releaseCategories, docsCategories };
+}
+
+function coverageFromReleaseItems(evidence, draft, items, index) {
+  const coveredRefs = [];
+  const coveredGroups = new Set();
+  const invalidItemRefs = [];
+  for (const item of items) {
+    for (const ref of item.source_refs || []) {
+      if (!coveredRefs.includes(ref)) coveredRefs.push(ref);
+      const groupKey = groupKeyForRef(ref, index.refToGroup);
+      if (index.groups.has(groupKey)) coveredGroups.add(groupKey);
+      if (index.knownRefs.size > 0 && !index.knownRefs.has(ref)) {
+        invalidItemRefs.push({
+          ref,
+          text_cn: item.text_cn,
+          category: item.category,
+        });
+      }
+    }
+  }
+
+  const required = [...index.groups.values()];
+  const missingRequired = required
+    .filter((group) => !coveredGroups.has(group.key))
+    .map((group) => ({
+      short_sha: group.refs.find((ref) => /^[a-f0-9]{7,40}$/.test(ref)) || "",
+      subject: group.subject,
+      refs: group.refs,
+      reason: group.reason || "important cloud plugin release source",
+    }));
+  const previousCoverage = draft.coverage || {};
+  const requiredCount = required.length || Number(previousCoverage.required_count || 0);
+  const missingRequiredCount = required.length
+    ? missingRequired.length
+    : Number(previousCoverage.missing_required_count || 0);
+  const coveredRequiredCount = required.length
+    ? required.length - missingRequired.length
+    : Number(previousCoverage.covered_required_count || 0);
+  const needsReview = missingRequiredCount > 0 || invalidItemRefs.length > 0 || items.length === 0;
+
+  return {
+    ...previousCoverage,
+    needs_review: needsReview,
+    required_count: requiredCount,
+    covered_required_count: coveredRequiredCount,
+    missing_required_count: missingRequiredCount,
+    missing_required: missingRequired,
+    invalid_item_refs: invalidItemRefs,
+    covered_refs: coveredRefs.sort(),
+    policy:
+      previousCoverage.policy ||
+      "important feat/fix/perf/refactor commits must be referenced by at least one bullet source_ref",
+  };
+}
+
+function languageIssuesFromReleaseItems(items) {
+  const issues = [];
+  for (const [index, item] of items.entries()) {
+    if (!CJK_RE.test(item.text_cn || "")) {
+      issues.push({
+        index,
+        category: item.category,
+        field: "text_cn",
+        current_text: item.text_cn || "",
+        reason: "Chinese release-note text must contain CJK characters.",
+      });
+    }
+    if (CJK_RE.test(item.text_en || "")) {
+      issues.push({
+        index,
+        category: item.category,
+        field: "text_en",
+        current_text: item.text_en || "",
+        reason: "English release-note text must not contain Chinese/CJK characters.",
+      });
+    }
+  }
+  return issues;
+}
+
+function summarizeCoverageForValidation(coverage) {
+  const value = coverage || {};
+  return {
+    needs_review: Boolean(value.needs_review),
+    required_count: Number(value.required_count || 0),
+    covered_required_count: Number(value.covered_required_count || 0),
+    missing_required_count: Number(value.missing_required_count || 0),
+    missing_required: Array.isArray(value.missing_required) ? value.missing_required : [],
+    invalid_item_refs: Array.isArray(value.invalid_item_refs) ? value.invalid_item_refs : [],
+  };
+}
+
+function validationReportFromPostprocessedDraft(draft) {
+  const coverage = summarizeCoverageForValidation(draft?.coverage);
+  const languageIssues = Array.isArray(draft?.language_issues) ? draft.language_issues : [];
+  const issues = [];
+  for (const issue of languageIssues) {
+    issues.push({
+      kind: "language",
+      index: issue.index,
+      category: issue.category,
+      field: issue.field,
+      current_text: issue.current_text || "",
+      reason: issue.reason,
+    });
+  }
+  for (const item of coverage.missing_required) {
+    issues.push({
+      kind: "missing_required_source",
+      refs: Array.isArray(item.refs) ? item.refs : [],
+      short_sha: item.short_sha || "",
+      subject: item.subject || "",
+      reason: item.reason || "important cloud plugin release source",
+    });
+  }
+  for (const item of coverage.invalid_item_refs) {
+    issues.push({
+      kind: "invalid_source_ref",
+      ref: item.ref || "",
+      category: item.category || "",
+      text_cn: item.text_cn || "",
+      reason: "release note cites a source_ref that is not present in evidence",
+    });
+  }
+  if (!Array.isArray(draft?.release_items) || draft.release_items.length === 0) {
+    issues.push({
+      kind: "empty_release_items",
+      reason: "release_items must contain at least one evidence-backed item",
+    });
+  }
+
+  const repairableKinds = new Set(["language", "missing_required_source"]);
+  const repairable =
+    issues.length > 0 &&
+    issues.every((issue) => repairableKinds.has(issue.kind)) &&
+    Array.isArray(draft?.release_items) &&
+    draft.release_items.length > 0;
+
+  return {
+    ok: Boolean(draft?.ok) && !draft?.needs_review && issues.length === 0,
+    needs_review: Boolean(draft?.needs_review),
+    repairable,
+    issue_count: issues.length,
+    language_issue_count: languageIssues.length,
+    invalid_item_ref_count: coverage.invalid_item_refs.length,
+    missing_required_count: coverage.missing_required_count,
+    issues,
+    coverage,
+    postprocess: draft?.postprocess || {},
+  };
+}
+
+function repairContextFromValidation({ draft, validationReport, repairAttempt, maxRepairAttempts }) {
+  return {
+    schema: "memos.plugin.release_notes.repair.v1",
+    repair_attempt: repairAttempt,
+    max_repair_attempts: maxRepairAttempts,
+    validation_report: validationReport,
+    previous_release_items: (draft.release_items || []).map((item, index) => ({
+      index,
+      category: item.category,
+      text_cn: item.text_cn,
+      text_en: item.text_en,
+      source_refs: item.source_refs,
+    })),
+    instructions: [
+      "Repair only the issues listed in validation_report. Do not rewrite already valid release-note facts.",
+      "For language issues, edit only the affected text_cn/text_en field: text_cn must contain Chinese, text_en must contain no Chinese/CJK characters.",
+      "Treat text_cn as the canonical wording first; text_en must be a faithful translation of text_cn, not an independently invented summary.",
+      "Keep existing valid category and source_refs unchanged. Do not add source_refs that are not present in the evidence.",
+      "For missing_required_source issues, add a concise product-facing item or attach the listed refs to a semantically matching existing item, using only the listed evidence.",
+      "Return the same release_items schema with category, text_cn, text_en, and source_refs.",
+    ],
+  };
+}
+
+function validationAttemptRecord({ stage, repairAttempt, draft, validationReport }) {
+  return {
+    stage,
+    repair_attempt: repairAttempt,
+    ok: validationReport.ok,
+    needs_review: validationReport.needs_review,
+    repairable: validationReport.repairable,
+    issue_count: validationReport.issue_count,
+    language_issue_count: validationReport.language_issue_count,
+    missing_required_count: validationReport.missing_required_count,
+    invalid_item_ref_count: validationReport.invalid_item_ref_count,
+    coverage: validationReport.coverage,
+    issues: validationReport.issues,
+    postprocess: draft.postprocess || {},
+  };
+}
+
+export async function requestValidatedDraft(
+  evidence,
+  {
+    requestImpl = requestDraft,
+    maxRepairAttempts = MAX_DRAFT_REPAIR_ATTEMPTS,
+  } = {},
+) {
+  let rawDraft = await requestImpl(evidence);
+  const attempts = [];
+  let finalDraft = null;
+
+  for (let repairAttempt = 0; repairAttempt <= maxRepairAttempts; repairAttempt += 1) {
+    const stage = repairAttempt === 0 ? "draft" : "repair";
+    const postprocessed = postprocessDraftFromEvidence(rawDraft, evidence);
+    const validationReport = validationReportFromPostprocessedDraft(postprocessed);
+    attempts.push(validationAttemptRecord({ stage, repairAttempt, draft: postprocessed, validationReport }));
+
+    finalDraft = {
+      ...postprocessed,
+      validation_report: validationReport,
+      repair_attempts: attempts,
+      validation_attempt_count: attempts.length,
+      repair_attempt_count: Math.max(0, attempts.length - 1),
+    };
+
+    if (validationReport.ok) {
+      return finalDraft;
+    }
+    if (!validationReport.repairable || repairAttempt >= maxRepairAttempts) {
+      return finalDraft;
+    }
+
+    const stageLabel =
+      repairAttempt === 0 ? "initial draft validation" : `repair validation attempt ${repairAttempt}`;
+    warn(
+      `Release notes validation failed after ${stageLabel}; requesting draft repair ` +
+        `${repairAttempt + 1}/${maxRepairAttempts}: ${validationReport.issues
+          .map((issue) => issue.kind)
+          .join(", ")}`,
+    );
+    rawDraft = await requestImpl({
+      ...evidence,
+      release_notes_repair_context: repairContextFromValidation({
+        draft: finalDraft,
+        validationReport,
+        repairAttempt: repairAttempt + 1,
+        maxRepairAttempts,
+      }),
+    });
+  }
+
+  return finalDraft;
+}
+
+function embeddedReleaseNotesPayload(items, coverage) {
+  return {
+    schema: "memos.plugin.release_notes.v1",
+    items: items.map((item) => ({
+      category: item.category,
+      text_cn: item.text_cn,
+      text_en: item.text_en,
+      source_refs: item.source_refs,
+    })),
+    coverage: {
+      needs_review: Boolean(coverage.needs_review),
+      required_count: Number(coverage.required_count || 0),
+      covered_required_count: Number(coverage.covered_required_count || 0),
+      missing_required_count: Number(coverage.missing_required_count || 0),
+    },
+  };
+}
+
+function markdownFromReleaseItems(items, coverage) {
+  const lines = ["## Changelog"];
+  for (const category of RELEASE_CATEGORY_ORDER) {
+    const categoryItems = items.filter((item) => item.category === category);
+    if (categoryItems.length === 0) continue;
+    lines.push("");
+    lines.push(`### ${category}`);
+    for (const item of categoryItems) {
+      lines.push(`- ${item.text_cn}`);
+    }
+  }
+  lines.push("");
+  lines.push(`<!-- ${RELEASE_NOTES_MARKER}`);
+  lines.push(JSON.stringify(embeddedReleaseNotesPayload(items, coverage), null, 2));
+  lines.push("-->");
+  return `${lines.join("\n").trim()}\n`;
+}
+
+export function postprocessDraftFromEvidence(draft, evidence) {
+  const inputItems = Array.isArray(draft?.release_items)
+    ? draft.release_items.map(normalizeReleaseItem).filter(Boolean)
+    : [];
+  if (inputItems.length === 0) return draft;
+
+  const index = buildSourceRefIndex(evidence);
+  let reclassifiedItems = 0;
+  let items = inputItems.map((item) => {
+    const hintedCategory = bestHintCategoryForItem(item, index);
+    const category = hintedCategory || item.category;
+    if (category !== item.category) reclassifiedItems += 1;
+    return { ...item, category };
+  });
+
+  const deduped = dedupeSourceRefsByBestCategory(items, index);
+  items = dedupeReleaseItems(
+    deduped.items.map((item) => {
+      const hintedCategory = bestHintCategoryForItem(item, index);
+      const category = hintedCategory || item.category;
+      if (category !== item.category) reclassifiedItems += 1;
+      return { ...item, category };
+    }),
+  );
+
+  const coverage = coverageFromReleaseItems(evidence, draft, items, index);
+  const languageIssues = languageIssuesFromReleaseItems(items);
+  if (languageIssues.length > 0) {
+    coverage.needs_review = true;
+  }
+  const { releaseCategories, docsCategories } = categoriesFromReleaseItems(items);
+  const postprocess = {
+    applied: true,
+    removed_duplicate_source_refs: deduped.removedDuplicateRefs,
+    dropped_empty_source_items: deduped.droppedItems,
+    reclassified_items: reclassifiedItems,
+    final_item_count: items.length,
+  };
+  const warnings = Array.isArray(draft.warnings) ? [...draft.warnings] : [];
+  if (
+    postprocess.removed_duplicate_source_refs > 0 ||
+    postprocess.dropped_empty_source_items > 0 ||
+    postprocess.reclassified_items > 0
+  ) {
+    warnings.push("release notes were postprocessed to dedupe source_refs and apply evidence category hints");
+  }
+  if (languageIssues.length > 0) {
+    warnings.push("release notes language validation failed; manual review is required");
+  }
+
+  return {
+    ...draft,
+    ok: Boolean(items.length) && !coverage.needs_review,
+    needs_review: Boolean(coverage.needs_review),
+    release_items: items,
+    release_categories: releaseCategories,
+    docs_categories: docsCategories,
+    coverage,
+    warnings,
+    language_issues: languageIssues,
+    postprocess,
+    release_notes_markdown: markdownFromReleaseItems(items, coverage),
+  };
+}
+
+export function validateManualNotes(notes) {
+  const text = String(notes || "").trim();
+  if (!/^## Changelog\s*$/m.test(text)) {
+    fail("Manual release notes must contain a '## Changelog' heading.");
+  }
+  const match = text.match(/<!--\s*doc-agent-release-notes-json\s*\n([\s\S]*?)\n-->/);
+  if (!match) {
+    fail("Manual release notes must include the doc-agent-release-notes-json evidence block.");
+  }
+  let payload;
+  try {
+    payload = JSON.parse(match[1]);
+  } catch {
+    fail("Manual release notes contain invalid doc-agent-release-notes-json.");
+  }
+  if (!Array.isArray(payload?.items) || payload.items.length === 0) {
+    fail("Manual release notes evidence block must contain non-empty items.");
+  }
+  if (payload?.coverage?.needs_review !== false) {
+    fail("Manual release notes evidence coverage must explicitly set needs_review=false.");
+  }
+  for (const item of payload.items) {
+    if (!item?.text_cn || !item?.text_en || !Array.isArray(item?.source_refs) || item.source_refs.length === 0) {
+      fail("Every manual release-note item must include text_cn, text_en, and source_refs.");
+    }
+    if (!CJK_RE.test(String(item.text_cn || ""))) {
+      fail("Every manual release-note item text_cn must contain Chinese text.");
+    }
+    if (CJK_RE.test(String(item.text_en || ""))) {
+      fail("Every manual release-note item text_en must not contain Chinese/CJK characters.");
+    }
+  }
+  return text;
+}
+
+function isRetryableStatus(status) {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function cleanError(value) {
+  return String(value || "")
+    .replace(/Bearer\s+\S+/gi, "Bearer ***")
+    .replace(/sk-[A-Za-z0-9_-]+/g, "sk-***")
+    .replace(/https?:\/\/[^\s"'<>]+/gi, "https://***")
+    .replace(/\b\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?\b/g, "***")
+    .replace(/\s+/g, " ")
+    .slice(0, 600);
+}
+
+function requiredUrlFromEnv(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) {
+    fail(`${name} secret is required when release_notes input is empty.`);
+  }
+  try {
+    const parsed = new URL(value);
+    if (!/^https?:$/.test(parsed.protocol)) fail(`${name} must be an HTTP(S) URL.`);
+  } catch {
+    fail(`${name} must be an HTTP(S) URL.`);
+  }
+  return value;
+}
+
+function optionalUrlFromEnv(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) return "";
+  try {
+    const parsed = new URL(value);
+    if (!/^https?:$/.test(parsed.protocol)) fail(`${name} must be an HTTP(S) URL.`);
+  } catch {
+    fail(`${name} must be an HTTP(S) URL.`);
+  }
+  return value;
+}
+
+export async function reportFailure({ evidence, attempts, finalError, phase = "release-notes", fetchImpl = fetch }) {
+  if (attempts.length < 3) return { skipped: true, reason: "fewer than three attempts" };
+  const token = process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN || "";
+  if (!token.trim()) return { skipped: true, reason: "missing configured token" };
+  const url = optionalUrlFromEnv("DOC_AGENT_RELEASE_FAILURE_URL");
+  if (!url) return { skipped: true, reason: "missing configured failure URL" };
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      product_id: PRODUCT_ID,
+      repository: evidence.repo,
+      version: evidence.target_version,
+      phase,
+      run_id: process.env.GITHUB_RUN_ID || `${evidence.current_tag}-cloud`,
+      run_url: process.env.GITHUB_RUN_ID
+        ? `https://github.com/${evidence.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
+        : "",
+      attempts: attempts.slice(0, 3).map((item, index) => ({
+        attempt: index + 1,
+        error_code: item.error_code || "DRAFT_FAILED",
+        message: cleanError(item.message),
+        retryable: Boolean(item.retryable),
+      })),
+      final_error: cleanError(finalError),
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Failure-report endpoint returned HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function reportExternalFailureFromEnv({ fetchImpl = fetch } = {}) {
+  const phase = String(process.env.RELEASE_FAILURE_PHASE || "").trim();
+  const attemptDir = String(process.env.RELEASE_FAILURE_ATTEMPT_DIR || "").trim();
+  if (!phase || !attemptDir) fail("RELEASE_FAILURE_PHASE and RELEASE_FAILURE_ATTEMPT_DIR are required.");
+  const attempts = [1, 2, 3].map((attempt) => {
+    let message = "attempt log is unavailable";
+    try { message = readFileSync(join(attemptDir, `${attempt}.log`), "utf8"); } catch {}
+    return { error_code: phase.toUpperCase().replace(/[^A-Z0-9]+/g, "_"), message: cleanError(message), retryable: true };
+  });
+  return reportFailure({
+    evidence: {
+      repo: process.env.GITHUB_REPOSITORY || REPOSITORY,
+      target_version: displayVersion(process.env.RELEASE_VERSION),
+      current_tag: process.env.RELEASE_TAG || `${CURRENT_TAG_PREFIX}${cleanVersion(process.env.RELEASE_VERSION)}`,
+    },
+    attempts,
+    finalError: attempts[2].message,
+    phase,
+    fetchImpl,
+  });
+}
+
+export async function requestDraft(
+  evidence,
+  { fetchImpl = fetch, sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)) } = {},
+) {
+  const url = requiredUrlFromEnv("DOC_AGENT_RELEASE_NOTES_DRAFT_URL");
+  const token = process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN || "";
+  if (!token.trim()) {
+    fail("DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN secret is required when release_notes input is empty.");
+  }
+
+  const attempts = [];
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          ...evidence,
+          workflow_retry_context: {
+            attempt,
+            previous_errors: attempts.map((item) => item.message),
+          },
+        }),
+      });
+      const text = await response.text();
+      let payload = {};
+      try {
+        payload = text ? JSON.parse(text) : {};
+      } catch {
+        throw Object.assign(new Error(`non-JSON response: HTTP ${response.status}`), {
+          retryable: isRetryableStatus(response.status),
+          errorCode: `HTTP_${response.status}`,
+        });
+      }
+      if (!response.ok) {
+        throw Object.assign(
+          new Error(`HTTP ${response.status} ${JSON.stringify(payload).slice(0, 400)}`),
+          { retryable: isRetryableStatus(response.status), errorCode: `HTTP_${response.status}` },
+        );
+      }
+      if (!payload.ok || payload.needs_review) {
+        const serverAttempts = Array.isArray(payload.attempts) ? payload.attempts : [];
+        const coverage = payload.coverage ? JSON.stringify(payload.coverage) : "";
+        const warnings = Array.isArray(payload.warnings) ? payload.warnings.join("; ") : "";
+        const message = `Release notes draft needs review. ${coverage} ${warnings}`.trim();
+        if (serverAttempts.length >= 3) {
+          await reportFailure({
+            evidence,
+            attempts: serverAttempts.map((item) => ({
+              error_code: "DRAFT_VALIDATION",
+              message: item.error || message,
+              retryable: false,
+            })),
+            finalError: message,
+            fetchImpl,
+          });
+        }
+        fail(message);
+      }
+      if (!String(payload.release_notes_markdown || "").trim()) {
+        fail("Release-notes draft service returned an empty release_notes_markdown.");
+      }
+      return payload;
+    } catch (error) {
+      const entry = {
+        error_code: error?.errorCode || "DRAFT_REQUEST",
+        message: cleanError(error?.message || error),
+        retryable: Boolean(error?.retryable),
+      };
+      attempts.push(entry);
+      if (!entry.retryable || attempt === 3) {
+        if (attempts.length === 3) {
+          await reportFailure({ evidence, attempts, finalError: entry.message, fetchImpl });
+        }
+        fail(`Release-notes draft request failed on attempt ${attempt}: ${entry.message}`);
+      }
+      warn(`Release-notes draft attempt ${attempt} failed; retrying: ${entry.message}`);
+      await sleep(250 * 2 ** (attempt - 1));
+    }
+  }
+  fail("Release-notes draft failed after three attempts.");
+}
+
+export async function main() {
+  const targetVersion = cleanVersion(process.env.RELEASE_VERSION);
+  if (!targetVersion) fail("RELEASE_VERSION is required.");
+
+  const currentTag = process.env.RELEASE_TAG || `${CURRENT_TAG_PREFIX}${targetVersion}`;
+  const notesPath =
+    process.env.RELEASE_NOTES_FILE ||
+    join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-release-notes.md`);
+  mkdirSync(dirname(notesPath), { recursive: true });
+
+  const manualNotes = String(process.env.MANUAL_RELEASE_NOTES || "").trim();
+  if (manualNotes) {
+    writeFileSync(notesPath, ensureSourceHint(validateManualNotes(manualNotes)), "utf8");
+    appendOutput("release_notes_file", notesPath);
+    appendOutput("draft_used", "false");
+    console.log(`Using manually provided release notes: ${notesPath}`);
+    return;
+  }
+
+  const previousTag = findPreviousTag(targetVersion, currentTag);
+  if (!previousTag) {
+    fail(`Cannot find a previous cloud plugin tag before ${currentTag}.`);
+  }
+
+  const currentRef = resolveCurrentRef(currentTag);
+  const evidence = collectEvidence({ targetVersion, currentTag, previousTag, currentRef });
+  const evidencePath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-evidence.json`);
+  writeFileSync(evidencePath, JSON.stringify(evidenceForInspection(evidence), null, 2), "utf8");
+
+  const draft = await requestValidatedDraft(evidence);
+  if (!draft.ok || draft.needs_review) {
+    fail(`Postprocessed release notes require review: ${JSON.stringify(draft.validation_report || draft.coverage || {})}`);
+  }
+  const draftPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-release-notes-draft.json`);
+  writeFileSync(draftPath, JSON.stringify(draftForInspection(draft), null, 2), "utf8");
+  writeFileSync(notesPath, ensureSourceHint(draft.release_notes_markdown), "utf8");
+
+  appendOutput("release_notes_file", notesPath);
+  appendOutput("evidence_file", evidencePath);
+  appendOutput("draft_file", draftPath);
+  appendOutput("draft_used", "true");
+  appendOutput("previous_tag", previousTag);
+  appendOutput("current_tag", currentTag);
+  appendOutput("current_ref", currentRef);
+  appendOutput("draft_confidence", String(draft.confidence || ""));
+  appendOutput("missing_required_count", String(draft.coverage?.missing_required_count ?? ""));
+  appendOutput("validation_attempt_count", String(draft.validation_attempt_count ?? ""));
+  appendOutput("repair_attempt_count", String(draft.repair_attempt_count ?? ""));
+
+  console.log(`Drafted release notes with configured service: ${notesPath}`);
+  console.log(`Previous tag: ${previousTag}`);
+  console.log(`Current tag: ${currentTag}`);
+  console.log(`Current evidence ref: ${currentRef}`);
+  console.log(`Coverage: ${JSON.stringify(draft.coverage || {})}`);
+  console.log(`Validation attempts: ${draft.validation_attempt_count ?? ""}`);
+  console.log(`Repair attempts: ${draft.repair_attempt_count ?? ""}`);
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+  const run = process.env.RELEASE_FAILURE_PHASE ? reportExternalFailureFromEnv : main;
+  run().catch((error) => {
+    console.error(`::error::${cleanError(error?.message || String(error))}`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -1,0 +1,481 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  cleanVersion,
+  categoryHintsForCommits,
+  draftForInspection,
+  evidenceForInspection,
+  ensureSourceHint,
+  postprocessDraftFromEvidence,
+  RELEASE_NOTE_GUIDANCE,
+  reportExternalFailureFromEnv,
+  requestDraft,
+  requestValidatedDraft,
+  resolveCurrentRef,
+  validateManualNotes,
+  versionFromTag,
+} from "./draft-cloud-plugin-release-notes.mjs";
+
+const evidence = {
+  repo: "MemTensor/MemOS-Cloud-OpenClaw-Plugin",
+  current_tag: "v0.1.19",
+  target_version: "v0.1.19",
+};
+
+function response(status, body) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    async text() {
+      return JSON.stringify(body);
+    },
+    async json() {
+      return body;
+    },
+  };
+}
+
+test("normalizes cloud plugin versions and tags", () => {
+  assert.equal(cleanVersion("v0.1.19"), "0.1.19");
+  assert.equal(versionFromTag("v0.1.19"), "0.1.19");
+  assert.equal(versionFromTag("openclaw-cloud-plugin-v0.1.19"), "");
+});
+
+test("uses an existing release tag as the evidence endpoint", () => {
+  const exists = (ref) => ref === "v0.1.19" || ref === "manual-ref";
+  assert.equal(resolveCurrentRef("v0.1.19", { requestedRef: "", refExistsImpl: exists }), "v0.1.19");
+  assert.equal(resolveCurrentRef("v0.1.20", { requestedRef: "", refExistsImpl: exists }), "HEAD");
+  assert.equal(resolveCurrentRef("v0.1.20", { requestedRef: "manual-ref", refExistsImpl: exists }), "manual-ref");
+  assert.throws(
+    () => resolveCurrentRef("v0.1.20", { requestedRef: "missing-ref", refExistsImpl: exists }),
+    /RELEASE_EVIDENCE_REF does not exist/,
+  );
+});
+
+test("documents cloud release-note guidance", () => {
+  assert.match(RELEASE_NOTE_GUIDANCE.category_policy.Added, /lifecycle hooks/);
+  assert.match(RELEASE_NOTE_GUIDANCE.category_policy.Improved, /prompt sanitization/);
+  assert.match(RELEASE_NOTE_GUIDANCE.category_policy.Fixed, /duplicate prompt injection/);
+  assert.ok(
+    RELEASE_NOTE_GUIDANCE.translation_policy.some((item) =>
+      item.includes("Treat text_cn as the canonical release-note wording first"),
+    ),
+  );
+});
+
+test("adds source-ref category hints from cloud plugin commit subjects", () => {
+  const hints = categoryHintsForCommits([
+    {
+      short_sha: "9deb941e",
+      subject: "feat: add direct-session user id support (#135)",
+    },
+    {
+      short_sha: "59c14746",
+      subject: "refactor: improve recall filter payload sanitization",
+    },
+    {
+      short_sha: "de03ab29",
+      subject: "fix: register before_prompt_build hook on supported OpenClaw hosts (#140)",
+    },
+    {
+      short_sha: "c739e9f2",
+      subject: "docs: update README",
+    },
+  ]);
+
+  assert.deepEqual(
+    hints.map((hint) => hint.category),
+    ["Added", "Improved", "Fixed"],
+  );
+  assert.deepEqual(hints[0].source_refs, ["9deb941e", "#135"]);
+  assert.deepEqual(hints[2].source_refs, ["de03ab29", "#140"]);
+});
+
+test("redacts full diff and prompt guidance from inspection evidence", () => {
+  const inspection = evidenceForInspection({
+    ...evidence,
+    release_note_guidance: {
+      category_policy: { Added: "private prompt details" },
+      quality_policy: ["private quality prompt"],
+      translation_policy: ["private translation prompt"],
+      source_ref_category_hints: [{ category: "Added", source_refs: ["abc1234"] }],
+    },
+    important_diff: {
+      "openclaw-cloud-plugin/**": "diff --git a/private.js b/private.js",
+    },
+  });
+
+  assert.equal("important_diff" in inspection, false);
+  assert.equal(inspection.release_note_guidance.category_policy, undefined);
+  assert.deepEqual(inspection.release_note_guidance.source_ref_category_hints, [
+    { category: "Added", source_refs: ["abc1234"] },
+  ]);
+  assert.match(inspection.redactions.important_diff, /omitted/);
+});
+
+test("redacts server debug fields from inspection draft", () => {
+  const inspection = draftForInspection({
+    ok: true,
+    needs_review: false,
+    confidence: "high",
+    release_items: [
+      { category: "Added", text_cn: "新增云插件配置", text_en: "Added cloud plugin configuration", source_refs: ["abc1234"] },
+    ],
+    coverage: { needs_review: false, required_count: 1, covered_required_count: 1, covered_refs: ["abc1234"] },
+    model: "private-model",
+    prompt: "private prompt",
+    debug: { trace: "private debug" },
+  });
+
+  assert.equal(inspection.model, undefined);
+  assert.equal(inspection.prompt, undefined);
+  assert.equal(inspection.debug, undefined);
+  assert.deepEqual(inspection.release_items[0].source_refs, ["abc1234"]);
+});
+
+test("postprocesses duplicate source refs into the best evidence category", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Fixed",
+          text_cn: "**召回过滤修复**：解决召回过滤 payload 处理问题。",
+          text_en: "**Recall Filter Fix**: Fixed recall filter payload handling.",
+          source_refs: ["59c14746"],
+        },
+        {
+          category: "Improved",
+          text_cn: "**召回过滤优化**：增强召回过滤 payload 清洗稳定性。",
+          text_en: "**Recall Filter Improvement**: Improved recall filter payload sanitization.",
+          source_refs: ["59c14746"],
+        },
+      ],
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits: [
+        {
+          sha: "59c1474600000000000000000000000000000000",
+          short_sha: "59c14746",
+          subject: "refactor: improve recall filter payload sanitization",
+        },
+      ],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Improved",
+            source_refs: ["59c14746"],
+            subject: "refactor: improve recall filter payload sanitization",
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.equal(processed.release_items.length, 1);
+  assert.equal(processed.release_items[0].category, "Improved");
+  assert.match(processed.release_notes_markdown, /doc-agent-release-notes-json/);
+});
+
+test("postprocess fails closed when English and Chinese text cross languages", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Added",
+          text_cn: "Plugin health dashboard",
+          text_en: "插件健康看板",
+          source_refs: ["abc1234", "#3001"],
+        },
+      ],
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits: [
+        {
+          sha: "abc12340000000000000000000000000000000",
+          short_sha: "abc1234",
+          subject: "feat: add plugin health dashboard (#3001)",
+        },
+      ],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Added",
+            source_refs: ["abc1234", "#3001"],
+            subject: "feat: add plugin health dashboard (#3001)",
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(processed.ok, false);
+  assert.equal(processed.needs_review, true);
+  assert.equal(processed.language_issues.length, 2);
+});
+
+test("repairs postprocessed language validation issues with exact context", async () => {
+  const repairEvidence = {
+    commits: [
+      {
+        sha: "abc12340000000000000000000000000000000",
+        short_sha: "abc1234",
+        subject: "feat: add plugin health dashboard (#3001)",
+      },
+    ],
+    release_note_guidance: {
+      source_ref_category_hints: [
+        {
+          category: "Added",
+          source_refs: ["abc1234", "#3001"],
+          subject: "feat: add plugin health dashboard (#3001)",
+        },
+      ],
+    },
+  };
+  const requests = [];
+  const requestImpl = async (payload) => {
+    requests.push(payload);
+    if (requests.length === 1) {
+      return {
+        ok: true,
+        needs_review: false,
+        release_items: [
+          {
+            category: "Added",
+            text_cn: "Plugin health dashboard",
+            text_en: "插件健康看板",
+            source_refs: ["abc1234", "#3001"],
+          },
+        ],
+        coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+        warnings: [],
+      };
+    }
+    return {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Added",
+          text_cn: "**插件健康看板**：新增云插件健康状态展示。",
+          text_en: "**Plugin Health Dashboard**: Added cloud plugin health status visibility.",
+          source_refs: ["abc1234", "#3001"],
+        },
+      ],
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    };
+  };
+
+  const result = await requestValidatedDraft(repairEvidence, { requestImpl });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.needs_review, false);
+  assert.equal(result.repair_attempt_count, 1);
+  assert.equal(result.validation_attempt_count, 2);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].release_notes_repair_context.validation_report.language_issue_count, 2);
+  assert.match(result.release_notes_markdown, /插件健康看板/);
+});
+
+test("stops release-note repair after two validation repair attempts", async () => {
+  const repairEvidence = {
+    commits: [
+      {
+        sha: "abc12340000000000000000000000000000000",
+        short_sha: "abc1234",
+        subject: "feat: add plugin health dashboard (#3001)",
+      },
+    ],
+    release_note_guidance: {
+      source_ref_category_hints: [
+        {
+          category: "Added",
+          source_refs: ["abc1234", "#3001"],
+          subject: "feat: add plugin health dashboard (#3001)",
+        },
+      ],
+    },
+  };
+  const crossedDraft = {
+    ok: true,
+    needs_review: false,
+    release_items: [
+      {
+        category: "Added",
+        text_cn: "Plugin health dashboard",
+        text_en: "插件健康看板",
+        source_refs: ["abc1234", "#3001"],
+      },
+    ],
+    coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+    warnings: [],
+  };
+  const requests = [];
+  const result = await requestValidatedDraft(repairEvidence, {
+    requestImpl: async (payload) => {
+      requests.push(payload);
+      return crossedDraft;
+    },
+    maxRepairAttempts: 2,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.needs_review, true);
+  assert.equal(result.repair_attempt_count, 2);
+  assert.equal(result.validation_attempt_count, 3);
+  assert.equal(requests.length, 3);
+});
+
+test("manual notes require bilingual evidence refs and passed coverage", () => {
+  const valid = `## Changelog
+
+### Added
+- cloud memory
+
+<!-- doc-agent-release-notes-json
+{"items":[{"text_cn":"云端记忆","text_en":"Cloud memory","source_refs":["abc1234"]}],"coverage":{"needs_review":false}}
+-->`;
+  assert.equal(validateManualNotes(valid), valid);
+  assert.match(ensureSourceHint(valid), /source-id=openclaw-cloud-plugin/);
+  assert.throws(() => validateManualNotes("## Changelog\n- unsupported"), /evidence block/);
+  assert.throws(
+    () =>
+      validateManualNotes(`## Changelog
+
+### Added
+- cloud memory
+
+<!-- doc-agent-release-notes-json
+{"items":[{"text_cn":"Cloud memory","text_en":"云端记忆","source_refs":["abc1234"]}],"coverage":{"needs_review":false}}
+-->`),
+    /text_cn must contain Chinese/,
+  );
+});
+
+test("reports three external-operation attempt logs with a sanitized phase", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "cloud-plugin-release-failure-"));
+  const previous = { ...process.env };
+  try {
+    for (const attempt of [1, 2, 3]) writeFileSync(join(directory, `${attempt}.log`), `npm failure ${attempt}`);
+    Object.assign(process.env, {
+      RELEASE_FAILURE_PHASE: "npm-publish",
+      RELEASE_FAILURE_ATTEMPT_DIR: directory,
+      RELEASE_VERSION: "0.1.19",
+      RELEASE_TAG: "v0.1.19",
+      DOC_AGENT_RELEASE_FAILURE_URL: "https://example.invalid/failure",
+      DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: "test-token",
+    });
+    let report;
+    await reportExternalFailureFromEnv({
+      fetchImpl: async (_url, options) => {
+        report = JSON.parse(options.body);
+        return response(200, { ok: true });
+      },
+    });
+    assert.equal(report.phase, "npm-publish");
+    assert.deepEqual(report.attempts.map((item) => item.message), ["npm failure 1", "npm failure 2", "npm failure 3"]);
+  } finally {
+    process.env = previous;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("retries transient draft failures and passes prior error context", async () => {
+  const previous = { ...process.env };
+  try {
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL = "https://example.invalid/draft";
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    const requests = [];
+    const fetchImpl = async (_url, options) => {
+      requests.push(JSON.parse(options.body));
+      if (requests.length < 3) return response(503, { detail: "busy" });
+      return response(200, {
+        ok: true,
+        needs_review: false,
+        release_notes_markdown: "## Changelog\n\n### Added\n- ok",
+      });
+    };
+    const result = await requestDraft(evidence, { fetchImpl, sleep: async () => {} });
+    assert.equal(result.ok, true);
+    assert.equal(requests.length, 3);
+    assert.equal(requests[1].workflow_retry_context.previous_errors.length, 1);
+    assert.equal(requests[2].workflow_retry_context.previous_errors.length, 2);
+  } finally {
+    process.env = previous;
+  }
+});
+
+test("reports once after three transient failures", async () => {
+  const previous = { ...process.env };
+  try {
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL = "https://example.invalid/draft";
+    process.env.DOC_AGENT_RELEASE_FAILURE_URL = "https://example.invalid/failure";
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    const calls = [];
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, body: JSON.parse(options.body) });
+      if (url.includes("/failure")) return response(200, { ok: true, sent: true });
+      return response(503, { detail: "busy" });
+    };
+    await assert.rejects(requestDraft(evidence, { fetchImpl, sleep: async () => {} }), /attempt 3/);
+    const reports = calls.filter((call) => call.url.includes("/failure"));
+    assert.equal(reports.length, 1);
+    assert.deepEqual(reports[0].body.attempts.map((item) => item.attempt), [1, 2, 3]);
+    assert.equal(reports[0].body.repository, "MemTensor/MemOS-Cloud-OpenClaw-Plugin");
+  } finally {
+    process.env = previous;
+  }
+});
+
+test("requires configured draft URL instead of using a public fallback", async () => {
+  const previous = { ...process.env };
+  try {
+    delete process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL;
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    await assert.rejects(
+      requestDraft(evidence, { fetchImpl: async () => response(200, { ok: true }), sleep: async () => {} }),
+      /DOC_AGENT_RELEASE_NOTES_DRAFT_URL secret is required/,
+    );
+  } finally {
+    process.env = previous;
+  }
+});
+
+test("sanitizes configured URLs and IPs before failure reporting", async () => {
+  const previous = { ...process.env };
+  try {
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL = "https://example.invalid/draft";
+    process.env.DOC_AGENT_RELEASE_FAILURE_URL = "https://example.invalid/failure";
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    const calls = [];
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, body: JSON.parse(options.body) });
+      if (url.includes("/failure")) return response(200, { ok: true, sent: true });
+      throw Object.assign(
+        new Error("connect ECONNREFUSED https://example.invalid/redacted-path 127.0.0.1:4318 with Bearer test-token"),
+        { retryable: true },
+      );
+    };
+    await assert.rejects(requestDraft(evidence, { fetchImpl, sleep: async () => {} }), /attempt 3/);
+    const report = calls.find((call) => call.url.includes("/failure"))?.body;
+    assert.ok(report);
+    assert.doesNotMatch(JSON.stringify(report), /example\.invalid|redacted-path|127\.0\.0\.1|test-token/);
+    assert.match(JSON.stringify(report), /https:\/\/\*\*\*/);
+  } finally {
+    process.env = previous;
+  }
+});

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+attempts="${RETRY_ATTEMPTS:-3}"
+delay="${RETRY_DELAY_SECONDS:-5}"
+label="command"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --attempts)
+      attempts="$2"
+      shift 2
+      ;;
+    --delay)
+      delay="$2"
+      shift 2
+      ;;
+    --label)
+      label="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::retry.sh requires a command to run." >&2
+  exit 2
+fi
+
+if ! [[ "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::Invalid retry attempts: ${attempts}" >&2
+  exit 2
+fi
+
+if ! [[ "${delay}" =~ ^[0-9]+$ ]]; then
+  echo "::error::Invalid retry delay: ${delay}" >&2
+  exit 2
+fi
+
+for attempt in $(seq 1 "${attempts}"); do
+  echo "::group::${label} attempt ${attempt}/${attempts}" >&2
+  set +e
+  "$@"
+  status=$?
+  set -e
+  echo "::endgroup::" >&2
+
+  if [ "${status}" -eq 0 ]; then
+    exit 0
+  fi
+
+  if [ "${attempt}" -eq "${attempts}" ]; then
+    echo "::error::${label} failed after ${attempts} attempts with exit code ${status}." >&2
+    exit "${status}"
+  fi
+
+  sleep_seconds=$((delay * attempt))
+  echo "::warning::${label} failed with exit code ${status}; retrying in ${sleep_seconds}s." >&2
+  sleep "${sleep_seconds}"
+done

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -1,0 +1,34 @@
+name: OpenClaw Cloud Plugin — Post-Merge Dry Run
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/release.yml"
+      - ".github/workflows/pre-merge-dry-run.yml"
+      - ".github/workflows/post-merge-dry-run.yml"
+      - ".github/scripts/draft-cloud-plugin-release-notes.mjs"
+      - ".github/scripts/draft-cloud-plugin-release-notes.test.mjs"
+      - ".github/scripts/retry.sh"
+      - "package.json"
+      - "scripts/generate-telemetry-credentials.cjs"
+      - "lib/arms-reporter.js"
+      - ".gitignore"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dry-run:
+    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      version: "0.1.19"
+      tag: "latest"
+      git_ref: ""
+      release_notes: ""
+      dry_run: true
+      recover_existing_npm_release: false
+    secrets: inherit

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -1,0 +1,63 @@
+name: OpenClaw Cloud Plugin — Pre-Merge Dry Run
+
+on:
+  push:
+    branches:
+      - "docs-sync/**"
+    paths:
+      - ".github/workflows/release.yml"
+      - ".github/workflows/pre-merge-dry-run.yml"
+      - ".github/workflows/post-merge-dry-run.yml"
+      - ".github/scripts/draft-cloud-plugin-release-notes.mjs"
+      - ".github/scripts/draft-cloud-plugin-release-notes.test.mjs"
+      - ".github/scripts/retry.sh"
+      - "package.json"
+      - "scripts/generate-telemetry-credentials.cjs"
+      - "lib/arms-reporter.js"
+      - ".gitignore"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  secrets-preflight:
+    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate dry-run secrets
+        shell: bash
+        env:
+          DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
+          DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
+          DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
+        run: |
+          set -euo pipefail
+          missing=0
+          if [ -z "${DOC_AGENT_RELEASE_NOTES_DRAFT_URL//[[:space:]]/}" ]; then
+            echo "::error::DOC_AGENT_RELEASE_NOTES_DRAFT_URL repository secret is required for evidence-backed dry runs."
+            missing=1
+          fi
+          if [ -z "${DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN//[[:space:]]/}" ]; then
+            echo "::error::DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN repository secret is required for evidence-backed dry runs."
+            missing=1
+          fi
+          if [ -z "${DOC_AGENT_RELEASE_FAILURE_URL//[[:space:]]/}" ]; then
+            echo "::warning::DOC_AGENT_RELEASE_FAILURE_URL is not set; exhausted retry notifications will be skipped."
+          fi
+          if [ "${missing}" -ne 0 ]; then
+            exit 1
+          fi
+
+  dry-run:
+    needs: secrets-preflight
+    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      version: "0.1.19"
+      tag: "latest"
+      git_ref: ""
+      release_notes: ""
+      dry_run: true
+      recover_existing_npm_release: false
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,149 @@
+name: OpenClaw Cloud Plugin — Publish & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.1.20 or 0.1.20-beta.1)"
+        required: true
+      tag:
+        description: "npm dist-tag (latest for production, beta/next/alpha for testing)"
+        required: true
+        default: "latest"
+      git_ref:
+        description: "Git ref to build from. Leave blank to use the branch selected above."
+        required: false
+        default: ""
+      release_notes:
+        description: "Markdown release notes for GitHub Release and docs changelog. Include a ## Changelog section."
+        required: true
+
+concurrency:
+  group: openclaw-cloud-plugin-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          if compgen -G "test/*.test.mjs" >/dev/null; then
+            node --test test/*.test.mjs
+          else
+            echo "No tests found; skipping."
+          fi
+
+      - name: Validate release notes
+        shell: bash
+        env:
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          if [ -z "$(printf '%s' "${RELEASE_NOTES}" | tr -d '[:space:]')" ]; then
+            echo "::error::release_notes is required so Doc Agent can update docs."
+            exit 1
+          fi
+          printf '%s\n' "${RELEASE_NOTES}" > release-notes.md
+
+      - name: Bump package and plugin versions
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          npm version "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
+          npm run sync-version
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGE_NAME: "@memtensor/memos-cloud-openclaw-plugin"
+          RELEASE_VERSION: ${{ inputs.version }}
+          NPM_DIST_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version >/dev/null 2>&1; then
+            echo "${PACKAGE_NAME}@${RELEASE_VERSION} already exists on npm; skipping publish."
+          else
+            npm publish --access public --tag "${NPM_DIST_TAG}"
+          fi
+
+      - name: Create release tag, GitHub Release, and version PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          release_tag="v${RELEASE_VERSION#v}"
+          release_branch="release/openclaw-cloud-plugin-${release_tag}"
+          release_title="release: @memtensor/memos-cloud-openclaw-plugin ${release_tag}"
+
+          git add package.json openclaw.plugin.json moltbot.plugin.json clawdbot.plugin.json
+          created_release_commit=false
+          if ! git diff --staged --quiet; then
+            git commit -m "${release_title}"
+            created_release_commit=true
+          fi
+
+          if [ "${created_release_commit}" = "true" ]; then
+            remote_branch_sha="$(git ls-remote --heads origin "${release_branch}" | awk '{print $1}')"
+            if [ -n "${remote_branch_sha}" ]; then
+              git push --force-with-lease="refs/heads/${release_branch}:${remote_branch_sha}" origin "HEAD:refs/heads/${release_branch}"
+            else
+              git push origin "HEAD:refs/heads/${release_branch}"
+            fi
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+            echo "Tag ${release_tag} already exists on origin; leaving it unchanged."
+          else
+            git tag "${release_tag}"
+            git push origin "refs/tags/${release_tag}"
+          fi
+
+          if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "GitHub Release ${release_tag} already exists; leaving it unchanged."
+          else
+            gh release create "${release_tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --target "$(git rev-parse HEAD)" \
+              --title "OpenClaw Cloud Plugin ${release_tag}" \
+              --notes-file release-notes.md
+          fi
+
+          if [ "${created_release_commit}" = "true" ]; then
+            if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              echo "Release PR already exists for ${release_branch}."
+            else
+              gh pr create \
+                --repo "${GITHUB_REPOSITORY}" \
+                --base "${DEFAULT_BRANCH}" \
+                --head "${release_branch}" \
+                --title "${release_title}" \
+                --body "Bumps package.json and plugin manifests for the published npm release ${release_tag}." \
+                || echo "::warning::Failed to create release PR automatically. Open a PR from ${release_branch} to ${DEFAULT_BRANCH}."
+            fi
+          else
+            echo "No version bump changes to open as a PR."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,50 @@ on:
         required: false
         default: ""
       release_notes:
-        description: "Markdown release notes for GitHub Release and docs changelog. Include a ## Changelog section."
+        description: "Optional evidence-backed Markdown. Leave blank to draft it from git evidence."
+        required: false
+        default: ""
+      dry_run:
+        description: "Build, validate, and generate inspection artifacts without publishing or changing GitHub."
         required: true
+        type: boolean
+        default: true
+      recover_existing_npm_release:
+        description: "Explicitly allow reconstructing GitHub metadata for a version already on npm. Keep false for normal releases."
+        required: true
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish or dry-run (e.g. 0.1.19 or 0.1.20-beta.1)"
+        required: true
+        type: string
+      tag:
+        description: "npm dist-tag (latest for production, beta/next/alpha for testing)"
+        required: false
+        type: string
+        default: "latest"
+      git_ref:
+        description: "Git ref to build from. Leave blank to use the caller ref."
+        required: false
+        type: string
+        default: ""
+      release_notes:
+        description: "Optional evidence-backed Markdown. Leave blank to draft it from git evidence."
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Build, validate, and generate inspection artifacts without publishing or changing GitHub."
+        required: false
+        type: boolean
+        default: true
+      recover_existing_npm_release:
+        description: "Allow reconstructing a missing tag/Release for an npm version. Keep false for normal releases."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: openclaw-cloud-plugin-publish
@@ -29,75 +71,416 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git_ref || github.ref }}
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Validate release inputs
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          NPM_DIST_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_VERSION}" == v* ]]; then
+            echo "::error::version must not include a leading v."
+            exit 1
+          fi
+          if ! [[ "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::version must be a semver value like 0.1.20 or 0.1.20-beta.1."
+            exit 1
+          fi
+          if [ -z "${NPM_DIST_TAG//[[:space:]]/}" ]; then
+            echo "::error::tag is required."
+            exit 1
+          fi
+          if ! [[ "${NPM_DIST_TAG}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "::error::tag must be a valid npm dist-tag."
+            exit 1
+          fi
+
       - name: Install dependencies
-        run: npm install
+        shell: bash
+        run: bash .github/scripts/retry.sh --label "npm install" -- npm install
 
       - name: Run tests
         shell: bash
         run: |
           set -euo pipefail
+          bash .github/scripts/retry.sh --attempts 2 --label "release notes tests" -- node --test .github/scripts/draft-cloud-plugin-release-notes.test.mjs
           if compgen -G "test/*.test.mjs" >/dev/null; then
-            node --test test/*.test.mjs
+            bash .github/scripts/retry.sh --attempts 2 --label "plugin tests" -- node --test test/*.test.mjs
           else
-            echo "No tests found; skipping."
+            echo "No plugin tests found; skipping."
           fi
-
-      - name: Validate release notes
-        shell: bash
-        env:
-          RELEASE_NOTES: ${{ inputs.release_notes }}
-        run: |
-          set -euo pipefail
-          if [ -z "$(printf '%s' "${RELEASE_NOTES}" | tr -d '[:space:]')" ]; then
-            echo "::error::release_notes is required so Doc Agent can update docs."
-            exit 1
-          fi
-          printf '%s\n' "${RELEASE_NOTES}" > release-notes.md
 
       - name: Bump package and plugin versions
+        shell: bash
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
-          npm version "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
+          set -euo pipefail
+          bash .github/scripts/retry.sh --label "bump package version" -- npm version "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
           npm run sync-version
 
+      - name: Generate telemetry credentials
+        shell: bash
+        env:
+          MEMOS_ARMS_ENDPOINT: ${{ secrets.MEMOS_ARMS_ENDPOINT }}
+          MEMOS_ARMS_PID: ${{ secrets.MEMOS_ARMS_PID }}
+          MEMOS_ARMS_ENV: ${{ secrets.MEMOS_ARMS_ENV }}
+        run: bash .github/scripts/retry.sh --label "generate telemetry credentials" -- node scripts/generate-telemetry-credentials.cjs
+
+      - name: Verify synchronized versions and package contents
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const expected = require('./package.json').version;
+          for (const file of ['openclaw.plugin.json', 'moltbot.plugin.json', 'clawdbot.plugin.json']) {
+            const actual = JSON.parse(fs.readFileSync(file, 'utf8')).version;
+            if (actual !== expected) throw new Error(`${file}: expected ${expected}, got ${actual}`);
+          }
+          NODE
+          bash .github/scripts/retry.sh --label "npm pack dry-run" -- bash -euo pipefail -c 'npm pack --dry-run --json > "${RUNNER_TEMP}/openclaw-cloud-plugin-pack.json"'
+
+      - name: Draft GitHub Release notes
+        id: release_notes
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: v${{ inputs.version }}
+          MANUAL_RELEASE_NOTES: ${{ inputs.release_notes }}
+          DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
+          DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
+          DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
+        run: bash .github/scripts/retry.sh --attempts 2 --label "draft GitHub Release notes" -- node .github/scripts/draft-cloud-plugin-release-notes.mjs
+
+      - name: Prepare release inspection artifact
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
+          EVIDENCE_FILE: ${{ steps.release_notes.outputs.evidence_file }}
+          DRAFT_FILE: ${{ steps.release_notes.outputs.draft_file }}
+          DRAFT_USED: ${{ steps.release_notes.outputs.draft_used }}
+          PREVIOUS_TAG: ${{ steps.release_notes.outputs.previous_tag }}
+          CURRENT_TAG: ${{ steps.release_notes.outputs.current_tag }}
+          CURRENT_REF: ${{ steps.release_notes.outputs.current_ref }}
+          DRAFT_CONFIDENCE: ${{ steps.release_notes.outputs.draft_confidence }}
+          MISSING_REQUIRED_COUNT: ${{ steps.release_notes.outputs.missing_required_count }}
+          VALIDATION_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.validation_attempt_count }}
+          REPAIR_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.repair_attempt_count }}
+        run: |
+          set -euo pipefail
+          inspection_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-inspection"
+          mkdir -p "${inspection_dir}"
+
+          if [ -z "${RELEASE_NOTES_FILE}" ] || [ ! -s "${RELEASE_NOTES_FILE}" ]; then
+            echo "::error::Release notes file was not generated."
+            exit 1
+          fi
+
+          cp "${RELEASE_NOTES_FILE}" "${inspection_dir}/release-notes.md"
+          cp "${RUNNER_TEMP}/openclaw-cloud-plugin-pack.json" "${inspection_dir}/npm-pack.json"
+          if [ -n "${EVIDENCE_FILE}" ] && [ -s "${EVIDENCE_FILE}" ]; then
+            cp "${EVIDENCE_FILE}" "${inspection_dir}/evidence.json"
+          fi
+          if [ "${DRAFT_USED:-}" = "true" ]; then
+            if [ -z "${DRAFT_FILE}" ] || [ ! -s "${DRAFT_FILE}" ]; then
+              echo "::error::Draft JSON file was not generated."
+              exit 1
+            fi
+            cp "${DRAFT_FILE}" "${inspection_dir}/release-notes-draft.json"
+          elif [ -n "${DRAFT_FILE}" ] && [ -s "${DRAFT_FILE}" ]; then
+            cp "${DRAFT_FILE}" "${inspection_dir}/release-notes-draft.json"
+          fi
+
+          {
+            echo "# OpenClaw cloud plugin release inspection"
+            echo
+            echo "- dry_run: ${DRY_RUN}"
+            echo "- version: ${RELEASE_VERSION}"
+            echo "- draft_used: ${DRAFT_USED:-unknown}"
+            echo "- previous_tag: ${PREVIOUS_TAG:-n/a}"
+            echo "- current_tag: ${CURRENT_TAG:-n/a}"
+            echo "- current_ref: ${CURRENT_REF:-n/a}"
+            echo "- draft_confidence: ${DRAFT_CONFIDENCE:-n/a}"
+            echo "- missing_required_count: ${MISSING_REQUIRED_COUNT:-n/a}"
+            echo "- validation_attempt_count: ${VALIDATION_ATTEMPT_COUNT:-n/a}"
+            echo "- repair_attempt_count: ${REPAIR_ATTEMPT_COUNT:-n/a}"
+            echo
+            echo "Files:"
+            echo
+            echo "- release-notes.md"
+            echo "- npm-pack.json"
+            if [ -n "${EVIDENCE_FILE}" ] && [ -s "${EVIDENCE_FILE}" ]; then
+              echo "- evidence.json (redacted; no full diff or prompt guidance)"
+            fi
+            if [ -f "${inspection_dir}/release-notes-draft.json" ]; then
+              echo "- release-notes-draft.json"
+            fi
+          } > "${inspection_dir}/README.md"
+
+          {
+            echo "### OpenClaw cloud plugin release notes"
+            echo
+            echo "- dry_run: \`${DRY_RUN}\`"
+            echo "- draft_used: \`${DRAFT_USED:-unknown}\`"
+            echo "- previous_tag: \`${PREVIOUS_TAG:-n/a}\`"
+            echo "- current_tag: \`${CURRENT_TAG:-n/a}\`"
+            echo "- current_ref: \`${CURRENT_REF:-n/a}\`"
+            echo "- draft_confidence: \`${DRAFT_CONFIDENCE:-n/a}\`"
+            echo "- missing_required_count: \`${MISSING_REQUIRED_COUNT:-n/a}\`"
+            echo "- validation_attempt_count: \`${VALIDATION_ATTEMPT_COUNT:-n/a}\`"
+            echo "- repair_attempt_count: \`${REPAIR_ATTEMPT_COUNT:-n/a}\`"
+            echo
+            echo "Download the workflow artifact \`openclaw-cloud-plugin-release-inspection\` to review release-notes.md, release-notes-draft.json, and redacted evidence.json."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload release inspection artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openclaw-cloud-plugin-release-inspection
+          path: ${{ runner.temp }}/openclaw-cloud-plugin-release-inspection
+          if-no-files-found: error
+
+      - name: Stop before publish in dry run
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "::notice::dry_run=true; skipped npm publish, tag, GitHub Release, and release PR."
+
       - name: Publish to npm
+        if: ${{ inputs.dry_run != true }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PACKAGE_NAME: "@memtensor/memos-cloud-openclaw-plugin"
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: v${{ inputs.version }}
           NPM_DIST_TAG: ${{ inputs.tag }}
+          RECOVER_EXISTING_NPM_RELEASE: ${{ inputs.recover_existing_npm_release }}
+          DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
+          DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
         run: |
           set -euo pipefail
-          if npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version >/dev/null 2>&1; then
-            echo "${PACKAGE_NAME}@${RELEASE_VERSION} already exists on npm; skipping publish."
+          npm_view_log="${RUNNER_TEMP}/openclaw-cloud-plugin-npm-view.log"
+          npm_version_exists() {
+            for attempt in 1 2 3; do
+              set +e
+              npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version >"${npm_view_log}" 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                sed -n '1,40p' "${npm_view_log}"
+                return 0
+              fi
+              if grep -Eiq "E404|404 Not Found|No match found|is not in this registry" "${npm_view_log}"; then
+                return 1
+              fi
+              sed -n '1,120p' "${npm_view_log}"
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::npm view failed after three attempts; refusing to guess whether ${PACKAGE_NAME}@${RELEASE_VERSION} exists."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          remote_tag_exists() {
+            local release_tag="$1"
+            for attempt in 1 2 3; do
+              set +e
+              git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                return 0
+              fi
+              if [ "${status}" = 2 ]; then
+                return 1
+              fi
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to check remote tag ${release_tag} after three attempts."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+
+          if npm_version_exists; then
+            release_tag="v${RELEASE_VERSION}"
+            if remote_tag_exists "${release_tag}"; then
+              echo "${PACKAGE_NAME}@${RELEASE_VERSION} and ${release_tag} already exist; treating this as an idempotent rerun."
+            elif [ "${RECOVER_EXISTING_NPM_RELEASE}" = "true" ]; then
+              echo "Recovery mode enabled; npm version exists, so publish is skipped."
+            else
+              echo "::error::npm version exists but ${release_tag} does not. Refusing to invent release metadata without explicit recovery mode."
+              exit 1
+            fi
           else
-            npm publish --access public --tag "${NPM_DIST_TAG}"
+            attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-npm-publish-attempts"
+            mkdir -p "${attempt_dir}"
+            for attempt in 1 2 3; do
+              set +e
+              npm publish --access public --tag "${NPM_DIST_TAG}" >"${attempt_dir}/${attempt}.log" 2>&1
+              publish_status=$?
+              set -e
+              sed -n '1,160p' "${attempt_dir}/${attempt}.log"
+              if [ "${publish_status}" = 0 ]; then
+                break
+              fi
+              if npm_version_exists; then
+                echo "Publish returned an error, but npm now contains the requested version."
+                break
+              fi
+              if [ "${attempt}" = 3 ]; then
+                RELEASE_FAILURE_PHASE=npm-publish \
+                  RELEASE_FAILURE_ATTEMPT_DIR="${attempt_dir}" \
+                  node .github/scripts/draft-cloud-plugin-release-notes.mjs \
+                  || echo "::warning::Failed to send the exhausted-retry notification."
+                echo "::error::npm publish failed after three attempts."
+                exit 1
+              fi
+              sleep "$((attempt * 5))"
+            done
+            if ! npm_version_exists; then
+              echo "::error::npm publish appeared to finish, but ${PACKAGE_NAME}@${RELEASE_VERSION} is still not visible."
+              exit 1
+            fi
           fi
 
       - name: Create release tag, GitHub Release, and version PR
+        if: ${{ inputs.dry_run != true }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ inputs.version }}
+          NPM_DIST_TAG: ${{ inputs.tag }}
+          RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
+          if [ -z "${RELEASE_NOTES_FILE}" ] || [ ! -s "${RELEASE_NOTES_FILE}" ]; then
+            echo "::error::Release notes file was not generated."
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           release_tag="v${RELEASE_VERSION#v}"
           release_branch="release/openclaw-cloud-plugin-${release_tag}"
           release_title="release: @memtensor/memos-cloud-openclaw-plugin ${release_tag}"
+          remote_branch_sha() {
+            local branch="$1"
+            local out="${RUNNER_TEMP}/openclaw-cloud-plugin-remote-branch.txt"
+            for attempt in 1 2 3; do
+              set +e
+              git ls-remote --heads origin "${branch}" >"${out}" 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                awk '{print $1}' "${out}"
+                return 0
+              fi
+              sed -n '1,120p' "${out}"
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to check remote branch ${branch} after three attempts."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          remote_tag_exists() {
+            local tag="$1"
+            for attempt in 1 2 3; do
+              set +e
+              git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                return 0
+              fi
+              if [ "${status}" = 2 ]; then
+                return 1
+              fi
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to check remote tag ${tag} after three attempts."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          create_release_if_missing() {
+            release_flags=()
+            if [[ "${RELEASE_VERSION}" == *-* || "${NPM_DIST_TAG}" != "latest" ]]; then
+              release_flags+=(--prerelease)
+              echo "Marking GitHub Release ${release_tag} as prerelease because version=${RELEASE_VERSION}, npm_dist_tag=${NPM_DIST_TAG}."
+            fi
+            for attempt in 1 2 3; do
+              if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+                echo "GitHub Release ${release_tag} already exists; leaving it unchanged."
+                return 0
+              fi
+              set +e
+              gh release create "${release_tag}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --target "$(git rev-parse HEAD)" \
+                --title "OpenClaw Cloud Plugin ${release_tag}" \
+                --notes-file "${RELEASE_NOTES_FILE}" \
+                "${release_flags[@]}"
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                return 0
+              fi
+              if [ "${attempt}" = 3 ]; then
+                if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+                  echo "GitHub Release ${release_tag} exists after a failed create response; treating as success."
+                  return 0
+                fi
+                echo "::error::Failed to create GitHub Release ${release_tag} after three attempts."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          create_pr_if_missing() {
+            if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              echo "Release PR already exists for ${release_branch}."
+              return 0
+            fi
+            for attempt in 1 2 3; do
+              set +e
+              gh pr create \
+                --repo "${GITHUB_REPOSITORY}" \
+                --base "${DEFAULT_BRANCH}" \
+                --head "${release_branch}" \
+                --title "${release_title}" \
+                --body "Bumps package.json and plugin manifests for the published npm release ${release_tag}."
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                return 0
+              fi
+              if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+                echo "Release PR exists after a failed create response; treating as success."
+                return 0
+              fi
+              if [ "${attempt}" = 3 ]; then
+                echo "::warning::Failed to create release PR automatically after three attempts. Open a PR from ${release_branch} to ${DEFAULT_BRANCH}."
+                return 0
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
 
           git add package.json openclaw.plugin.json moltbot.plugin.json clawdbot.plugin.json
           created_release_commit=false
@@ -107,43 +490,29 @@ jobs:
           fi
 
           if [ "${created_release_commit}" = "true" ]; then
-            remote_branch_sha="$(git ls-remote --heads origin "${release_branch}" | awk '{print $1}')"
+            remote_branch_sha="$(remote_branch_sha "${release_branch}")"
             if [ -n "${remote_branch_sha}" ]; then
-              git push --force-with-lease="refs/heads/${release_branch}:${remote_branch_sha}" origin "HEAD:refs/heads/${release_branch}"
+              if [ "${remote_branch_sha}" != "$(git rev-parse HEAD)" ]; then
+                echo "::error::Release branch ${release_branch} already exists at a different commit; refusing to overwrite it."
+                exit 1
+              fi
+              echo "Release branch ${release_branch} already points at this commit."
             else
-              git push origin "HEAD:refs/heads/${release_branch}"
+              bash .github/scripts/retry.sh --label "push release branch" -- git push origin "HEAD:refs/heads/${release_branch}"
             fi
           fi
 
-          if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+          if remote_tag_exists "${release_tag}"; then
             echo "Tag ${release_tag} already exists on origin; leaving it unchanged."
           else
             git tag "${release_tag}"
-            git push origin "refs/tags/${release_tag}"
+            bash .github/scripts/retry.sh --label "push release tag" -- git push origin "refs/tags/${release_tag}"
           fi
 
-          if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "GitHub Release ${release_tag} already exists; leaving it unchanged."
-          else
-            gh release create "${release_tag}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --target "$(git rev-parse HEAD)" \
-              --title "OpenClaw Cloud Plugin ${release_tag}" \
-              --notes-file release-notes.md
-          fi
+          create_release_if_missing
 
           if [ "${created_release_commit}" = "true" ]; then
-            if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-              echo "Release PR already exists for ${release_branch}."
-            else
-              gh pr create \
-                --repo "${GITHUB_REPOSITORY}" \
-                --base "${DEFAULT_BRANCH}" \
-                --head "${release_branch}" \
-                --title "${release_title}" \
-                --body "Bumps package.json and plugin manifests for the published npm release ${release_tag}." \
-                || echo "::warning::Failed to create release PR automatically. Open a PR from ${release_branch} to ${DEFAULT_BRANCH}."
-            fi
+            create_pr_if_missing
           else
             echo "No version bump changes to open as a PR."
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 .env
 .env.*
 .memos_arms_uid
+telemetry.credentials.json
 
 # NPM
 .npmrc

--- a/lib/arms-reporter.js
+++ b/lib/arms-reporter.js
@@ -13,24 +13,24 @@ function loadTelemetryCredentials(log) {
   if (telemetryCredentialsCache) return telemetryCredentialsCache;
   if (process.env.MEMOS_ARMS_ENDPOINT) {
     telemetryCredentialsCache = {
-      endpoint: process.env.MEMOS_ARMS_ENDPOINT,
-      pid: process.env.MEMOS_ARMS_PID || "",
-      env: process.env.MEMOS_ARMS_ENV || "prod",
+      endpoint: String(process.env.MEMOS_ARMS_ENDPOINT || "").trim(),
+      pid: String(process.env.MEMOS_ARMS_PID || "").trim(),
+      env: String(process.env.MEMOS_ARMS_ENV || "prod").trim() || "prod",
     };
-    return telemetryCredentialsCache;
+  } else {
+    try {
+      const parsed = JSON.parse(readFileSync(TELEMETRY_CREDENTIALS_FILE, "utf-8"));
+      telemetryCredentialsCache = {
+        endpoint: String(parsed.endpoint || "").trim(),
+        pid: String(parsed.pid || "").trim(),
+        env: String(parsed.env || "prod").trim() || "prod",
+      };
+    } catch {
+      telemetryCredentialsCache = { endpoint: "", pid: "", env: "prod" };
+    }
   }
-  try {
-    const parsed = JSON.parse(readFileSync(TELEMETRY_CREDENTIALS_FILE, "utf-8"));
-    telemetryCredentialsCache = {
-      endpoint: String(parsed.endpoint || ""),
-      pid: String(parsed.pid || ""),
-      env: String(parsed.env || "prod"),
-    };
-  } catch {
-    telemetryCredentialsCache = { endpoint: "", pid: "", env: "prod" };
-  }
-  if (!telemetryCredentialsCache.endpoint) {
-    log?.debug?.("[memos-cloud] RUM disabled: telemetry credentials are not configured.");
+  if (!telemetryCredentialsCache.endpoint || !telemetryCredentialsCache.pid) {
+    log?.debug?.("[memos-cloud] RUM disabled: telemetry credentials are incomplete.");
   }
   return telemetryCredentialsCache;
 }
@@ -118,7 +118,7 @@ function buildPayload(ctx, eventName, payload, log, credentials) {
 export async function reportRumEvent(eventName, payload, cfg, ctx, log) {
   if (!cfg.rumEnabled) return;
   const credentials = loadTelemetryCredentials(log);
-  if (!credentials.endpoint) return;
+  if (!credentials.endpoint || !credentials.pid) return;
   const controller = new AbortController();
   const timeoutId = setTimeout(
     () => controller.abort(),

--- a/lib/arms-reporter.js
+++ b/lib/arms-reporter.js
@@ -3,12 +3,37 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const ARMS_ENDPOINT = "https://proj-xtrace-e218d9316b328f196a3c640cc7ca84-cn-hangzhou.cn-hangzhou.log.aliyuncs.com/rum/web/v2?workspace=default-cms-1026429231103299-cn-hangzhou&service_id=a3u72ukxmr@bed68dd882dd823439015"
-const ARMS_PID = "a3u72ukxmr@c42a249fb14f4d9";
-const ARMS_ENV = "prod";
 const ARMS_UID_FILE = new URL("../.memos_arms_uid", import.meta.url);
+const TELEMETRY_CREDENTIALS_FILE = new URL("../telemetry.credentials.json", import.meta.url);
 
 let armsUidCache = "";
+let telemetryCredentialsCache;
+
+function loadTelemetryCredentials(log) {
+  if (telemetryCredentialsCache) return telemetryCredentialsCache;
+  if (process.env.MEMOS_ARMS_ENDPOINT) {
+    telemetryCredentialsCache = {
+      endpoint: process.env.MEMOS_ARMS_ENDPOINT,
+      pid: process.env.MEMOS_ARMS_PID || "",
+      env: process.env.MEMOS_ARMS_ENV || "prod",
+    };
+    return telemetryCredentialsCache;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(TELEMETRY_CREDENTIALS_FILE, "utf-8"));
+    telemetryCredentialsCache = {
+      endpoint: String(parsed.endpoint || ""),
+      pid: String(parsed.pid || ""),
+      env: String(parsed.env || "prod"),
+    };
+  } catch {
+    telemetryCredentialsCache = { endpoint: "", pid: "", env: "prod" };
+  }
+  if (!telemetryCredentialsCache.endpoint) {
+    log?.debug?.("[memos-cloud] RUM disabled: telemetry credentials are not configured.");
+  }
+  return telemetryCredentialsCache;
+}
 
 function readUidFromFile() {
   try {
@@ -65,11 +90,11 @@ function loadArmsUid(log) {
   return armsUidCache;
 }
 
-function buildPayload(ctx, eventName, payload, log) {
+function buildPayload(ctx, eventName, payload, log, credentials) {
   return {
     app: {
-      id: ARMS_PID,
-      env: ARMS_ENV,
+      id: credentials.pid,
+      env: credentials.env,
       type: "node",
     },
     user: { id: loadArmsUid(log) },
@@ -92,14 +117,16 @@ function buildPayload(ctx, eventName, payload, log) {
 
 export async function reportRumEvent(eventName, payload, cfg, ctx, log) {
   if (!cfg.rumEnabled) return;
+  const credentials = loadTelemetryCredentials(log);
+  if (!credentials.endpoint) return;
   const controller = new AbortController();
   const timeoutId = setTimeout(
     () => controller.abort(),
     Number.isFinite(cfg.rumTimeoutMs) ? Math.max(1000, cfg.rumTimeoutMs) : 3000,
   );
   try {
-    const body = buildPayload(ctx, eventName, payload, log);
-    const res = await fetch(ARMS_ENDPOINT, {
+    const body = buildPayload(ctx, eventName, payload, log, credentials);
+    const res = await fetch(credentials.endpoint, {
       method: "POST",
       headers: { "Content-Type": "text/plain" },
       body: JSON.stringify(body),

--- a/package.json
+++ b/package.json
@@ -2,7 +2,17 @@
   "name": "@memtensor/memos-cloud-openclaw-plugin",
   "version": "0.1.19",
   "description": "OpenClaw lifecycle plugin for MemOS Cloud (add + recall memory)",
+  "files": [
+    "index.js",
+    "lib",
+    "openclaw.plugin.json",
+    "moltbot.plugin.json",
+    "clawdbot.plugin.json",
+    "telemetry.credentials.json"
+  ],
   "scripts": {
+    "test": "node --test .github/scripts/draft-cloud-plugin-release-notes.test.mjs test/*.test.mjs",
+    "generate-telemetry-credentials": "node scripts/generate-telemetry-credentials.cjs",
     "sync-version": "node scripts/sync-version.js",
     "version": "npm run sync-version && git add openclaw.plugin.json moltbot.plugin.json clawdbot.plugin.json",
     "publish-beta": "npm publish --tag beta",

--- a/scripts/generate-telemetry-credentials.cjs
+++ b/scripts/generate-telemetry-credentials.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Generate telemetry.credentials.json from environment variables.
+ *
+ * CI calls this before npm packaging so the published artifact can include
+ * telemetry credentials while the git repository stays free of cloud resource
+ * identifiers.
+ *
+ * Required env vars:
+ *   MEMOS_ARMS_ENDPOINT  - full ARMS RUM endpoint URL
+ *   MEMOS_ARMS_PID       - ARMS application PID
+ *   MEMOS_ARMS_ENV       - environment tag (default: "prod")
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const endpoint = process.env.MEMOS_ARMS_ENDPOINT || "";
+const pid = process.env.MEMOS_ARMS_PID || "";
+const env = process.env.MEMOS_ARMS_ENV || "prod";
+
+if (!endpoint) {
+  console.warn(
+    "[generate-telemetry-credentials] MEMOS_ARMS_ENDPOINT not set; " +
+      "skipping. RUM telemetry will be disabled in this build.",
+  );
+  process.exit(0);
+}
+
+const out = path.resolve(__dirname, "..", "telemetry.credentials.json");
+fs.writeFileSync(out, JSON.stringify({ endpoint, pid, env }, null, 2) + "\n", "utf-8");
+console.log("[generate-telemetry-credentials] wrote " + out);

--- a/scripts/generate-telemetry-credentials.cjs
+++ b/scripts/generate-telemetry-credentials.cjs
@@ -15,16 +15,37 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-const endpoint = process.env.MEMOS_ARMS_ENDPOINT || "";
-const pid = process.env.MEMOS_ARMS_PID || "";
-const env = process.env.MEMOS_ARMS_ENV || "prod";
+const endpoint = String(process.env.MEMOS_ARMS_ENDPOINT || "").trim();
+const pid = String(process.env.MEMOS_ARMS_PID || "").trim();
+const env = String(process.env.MEMOS_ARMS_ENV || "prod").trim() || "prod";
 
-if (!endpoint) {
+if (!endpoint && !pid) {
   console.warn(
     "[generate-telemetry-credentials] MEMOS_ARMS_ENDPOINT not set; " +
       "skipping. RUM telemetry will be disabled in this build.",
   );
   process.exit(0);
+}
+
+if (!endpoint || !pid) {
+  console.error(
+    "[generate-telemetry-credentials] MEMOS_ARMS_ENDPOINT and MEMOS_ARMS_PID " +
+      "must be set together. Refusing to write partial telemetry credentials.",
+  );
+  process.exit(1);
+}
+
+let parsedEndpoint;
+try {
+  parsedEndpoint = new URL(endpoint);
+} catch {
+  console.error("[generate-telemetry-credentials] MEMOS_ARMS_ENDPOINT must be a valid URL.");
+  process.exit(1);
+}
+
+if (!["http:", "https:"].includes(parsedEndpoint.protocol)) {
+  console.error("[generate-telemetry-credentials] MEMOS_ARMS_ENDPOINT must use http or https.");
+  process.exit(1);
 }
 
 const out = path.resolve(__dirname, "..", "telemetry.credentials.json");


### PR DESCRIPTION
## Summary

- Add an OpenClaw cloud plugin publish/release workflow aligned with the MemOS local plugin release flow.
- Add pre-merge and post-merge dry-run workflows that validate 0.1.19 without publishing.
- Generate evidence-backed GitHub Release notes through Doc Agent and upload a redacted inspection artifact.
- Move telemetry credentials to CI secrets and fail closed on partial telemetry configuration.

## Safety

- dry_run=true stops before npm publish, tag creation, GitHub Release creation, and release PR creation.
- No real internal URL, token, npm token, or cloud resource identifier is committed.
- Historical tags v0.1.15..v0.1.19 are already present only as Git tags; this PR does not create historical GitHub Releases.
- Real npm publish still requires NPM_TOKEN to be configured later.

## Validation

- Release notes script tests: 16/16 passing.
- Plugin tests: 45/45 passing.
- pnpm pack --dry-run --json includes runtime files only; no .github or test files in the package.
- Pre-merge dry-run passed: https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin/actions/runs/29914887530
- Inspection artifact digest: sha256:985f6356c341490e1c74c06fcde25030605ee98150e03d24f549ec0d9c9be16d.
