### PR TITLE
fix: compare release tags with semver precedence

### DIFF
--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -4,6 +4,9 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
+import { cleanVersion, compareSemver, parseSemver } from "../../lib/semver.js";
+
+export { cleanVersion, compareSemver, parseSemver };
 
 export const PRODUCT_ID = "openclaw-cloud-plugin";
 export const PRODUCT_TITLE = {
@@ -62,11 +65,6 @@ function git(args, options = {}) {
   }).trim();
 }
 
-export function cleanVersion(raw) {
-  const value = String(raw || "").trim();
-  return value.startsWith("v") ? value.slice(1) : value;
-}
-
 export function displayVersion(raw) {
   const value = cleanVersion(raw);
   return value ? `v${value}` : "";
@@ -76,31 +74,6 @@ export function versionFromTag(tag) {
   const value = String(tag || "").trim();
   if (!value.startsWith(CURRENT_TAG_PREFIX)) return "";
   return cleanVersion(value.slice(CURRENT_TAG_PREFIX.length));
-}
-
-export function parseSemver(version) {
-  const cleaned = cleanVersion(version);
-  const match = cleaned.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+]([0-9A-Za-z.-]+))?$/);
-  if (!match) return null;
-  return {
-    major: Number(match[1]),
-    minor: Number(match[2]),
-    patch: Number(match[3]),
-    prerelease: match[4] || "",
-  };
-}
-
-export function compareSemver(a, b) {
-  const av = parseSemver(a);
-  const bv = parseSemver(b);
-  if (!av || !bv) return String(a).localeCompare(String(b));
-  for (const key of ["major", "minor", "patch"]) {
-    if (av[key] !== bv[key]) return av[key] - bv[key];
-  }
-  if (av.prerelease === bv.prerelease) return 0;
-  if (!av.prerelease) return 1;
-  if (!bv.prerelease) return -1;
-  return av.prerelease.localeCompare(bv.prerelease);
 }
 
 function gitShowJson(ref, path) {

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,9 +8,11 @@ import test from "node:test";
 import {
   cleanVersion,
   categoryHintsForCommits,
+  compareSemver,
   draftForInspection,
   evidenceForInspection,
   ensureSourceHint,
+  findPreviousTag,
   postprocessDraftFromEvidence,
   RELEASE_NOTE_GUIDANCE,
   reportExternalFailureFromEnv,
@@ -25,6 +28,14 @@ const evidence = {
   current_tag: "v0.1.19",
   target_version: "v0.1.19",
 };
+
+function runGit(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
 
 function response(status, body) {
   return {
@@ -43,6 +54,43 @@ test("normalizes cloud plugin versions and tags", () => {
   assert.equal(cleanVersion("v0.1.19"), "0.1.19");
   assert.equal(versionFromTag("v0.1.19"), "0.1.19");
   assert.equal(versionFromTag("openclaw-cloud-plugin-v0.1.19"), "");
+});
+
+test("compares SemVer prerelease identifiers numerically and ignores build metadata", () => {
+  assert.equal(compareSemver("1.0.0-beta.10", "1.0.0-beta.9") > 0, true);
+  assert.equal(compareSemver("1.0.0-beta.20", "1.0.0-beta.19") > 0, true);
+  assert.equal(compareSemver("1.0.0-beta.1", "1.0.0-beta.alpha") < 0, true);
+  assert.equal(compareSemver("1.0.0", "1.0.0-rc.1") > 0, true);
+  assert.equal(compareSemver("1.0.0+build.2", "1.0.0+build.1"), 0);
+  assert.equal(compareSemver("1.0.0-beta.1+build.2", "1.0.0-beta.1+build.1"), 0);
+});
+
+test("finds previous tags using SemVer precedence for prerelease numbers", () => {
+  const previousCwd = process.cwd();
+  const dir = mkdtempSync(join(tmpdir(), "openclaw-cloud-tags-"));
+
+  try {
+    runGit(dir, ["init"]);
+    runGit(dir, ["config", "user.email", "test@example.invalid"]);
+    runGit(dir, ["config", "user.name", "Test User"]);
+    writeFileSync(join(dir, "README.md"), "tags\n");
+    runGit(dir, ["add", "README.md"]);
+    runGit(dir, ["commit", "-m", "seed"]);
+    runGit(dir, ["tag", "v1.0.0"]);
+    runGit(dir, ["tag", "v1.0.1+build.1"]);
+    for (let i = 1; i <= 19; i++) {
+      runGit(dir, ["tag", `v1.0.0-beta.${i}`]);
+    }
+
+    process.chdir(dir);
+    assert.equal(findPreviousTag("1.0.0-beta.10", "v1.0.0-beta.10"), "v1.0.0-beta.9");
+    assert.equal(findPreviousTag("1.0.0-beta.11", "v1.0.0-beta.11"), "v1.0.0-beta.10");
+    assert.equal(findPreviousTag("1.0.0-beta.20", "v1.0.0-beta.20"), "v1.0.0-beta.19");
+    assert.equal(findPreviousTag("1.0.1+build.2", "v1.0.1+build.2"), "v1.0.0");
+  } finally {
+    process.chdir(previousCwd);
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("uses an existing release tag as the evidence endpoint", () => {

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -13,7 +13,8 @@ on:
       - ".github/scripts/retry.sh"
       - "package.json"
       - "scripts/generate-telemetry-credentials.cjs"
-      - "lib/arms-reporter.js"
+      - "lib/**"
+      - "test/*.test.mjs"
       - ".gitignore"
 
 permissions:

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -13,7 +13,8 @@ on:
       - ".github/scripts/retry.sh"
       - "package.json"
       - "scripts/generate-telemetry-credentials.cjs"
-      - "lib/arms-reporter.js"
+      - "lib/**"
+      - "test/*.test.mjs"
       - ".gitignore"
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,12 +90,12 @@ jobs:
           NPM_DIST_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          if [[ "${RELEASE_VERSION}" == v* ]]; then
+          if [[ "${RELEASE_VERSION}" == [vV]* ]]; then
             echo "::error::version must not include a leading v."
             exit 1
           fi
-          if ! [[ "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::version must be a semver value like 0.1.20 or 0.1.20-beta.1."
+          if ! [[ "${RELEASE_VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "::error::version must be a SemVer value like 0.1.20, 0.1.20-beta.1, or 0.1.20+build.1."
             exit 1
           fi
           if [ -z "${NPM_DIST_TAG//[[:space:]]/}" ]; then

--- a/lib/check-update.js
+++ b/lib/check-update.js
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import os from "os";
+import { compareSemver } from "./semver.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -69,36 +70,7 @@ export function getLatestVersion() {
 }
 
 export function compareVersions(v1, v2) {
-  // Split pre-release tags (e.g. 0.1.8-beta.1 -> "0.1.8" and "beta.1")
-  const split1 = v1.split("-");
-  const split2 = v2.split("-");
-  const parts1 = split1[0].split(".").map(Number);
-  const parts2 = split2[0].split(".").map(Number);
-  
-  // Compare major.minor.patch
-  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-    const p1 = parts1[i] || 0;
-    const p2 = parts2[i] || 0;
-    if (p1 > p2) return 1;
-    if (p1 < p2) return -1;
-  }
-  
-  // If base versions are equal, compare pre-release tags.
-  // A version WITH a pre-release tag is LOWER than a version WITHOUT one.
-  // e.g. 0.1.8-beta is less than 0.1.8. 0.1.8 is the final release.
-  const hasPre1 = split1.length > 1;
-  const hasPre2 = split2.length > 1;
-  
-  if (hasPre1 && !hasPre2) return -1; // v1 is a beta, v2 is a full release
-  if (!hasPre1 && hasPre2) return 1;  // v1 is a full release, v2 is a beta
-  if (!hasPre1 && !hasPre2) return 0; // both are full releases and equal
-  
-  // If both are pre-releases, do a basic string compare on the tag
-  // "alpha" < "beta" < "rc"
-  if (split1[1] > split2[1]) return 1;
-  if (split1[1] < split2[1]) return -1;
-  
-  return 0;
+  return compareSemver(v1, v2);
 }
 
 function detectCliName() {

--- a/lib/semver.js
+++ b/lib/semver.js
@@ -1,0 +1,91 @@
+const SEMVER_RE =
+  /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const CORE_NUMBER_RE = /^(0|[1-9]\d*)$/;
+const NUMERIC_IDENTIFIER_RE = /^\d+$/;
+
+function compareString(a, b) {
+  if (a > b) return 1;
+  if (a < b) return -1;
+  return 0;
+}
+
+function parseIdentifierList(raw, { rejectLeadingZeroNumeric }) {
+  if (!raw) return [];
+
+  const identifiers = raw.split(".");
+  for (const identifier of identifiers) {
+    if (!identifier) return null;
+    if (rejectLeadingZeroNumeric && NUMERIC_IDENTIFIER_RE.test(identifier) && !CORE_NUMBER_RE.test(identifier)) {
+      return null;
+    }
+  }
+  return identifiers;
+}
+
+export function cleanVersion(raw) {
+  const value = String(raw || "").trim();
+  return value.startsWith("v") || value.startsWith("V") ? value.slice(1) : value;
+}
+
+export function parseSemver(version) {
+  const cleaned = cleanVersion(version);
+  const match = cleaned.match(SEMVER_RE);
+  if (!match) return null;
+  if (![match[1], match[2], match[3]].every((part) => CORE_NUMBER_RE.test(part))) return null;
+
+  const prerelease = parseIdentifierList(match[4] || "", { rejectLeadingZeroNumeric: true });
+  const build = parseIdentifierList(match[5] || "", { rejectLeadingZeroNumeric: false });
+  if (!prerelease || !build) return null;
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease,
+    build,
+  };
+}
+
+function comparePrereleaseIdentifier(a, b) {
+  const aNumeric = NUMERIC_IDENTIFIER_RE.test(a);
+  const bNumeric = NUMERIC_IDENTIFIER_RE.test(b);
+
+  if (aNumeric && bNumeric) {
+    const ai = BigInt(a);
+    const bi = BigInt(b);
+    if (ai > bi) return 1;
+    if (ai < bi) return -1;
+    return 0;
+  }
+  if (aNumeric) return -1;
+  if (bNumeric) return 1;
+  return compareString(a, b);
+}
+
+function comparePrerelease(a, b) {
+  if (a.length === 0 && b.length === 0) return 0;
+  if (a.length === 0) return 1;
+  if (b.length === 0) return -1;
+
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    if (a[i] === undefined) return -1;
+    if (b[i] === undefined) return 1;
+    const result = comparePrereleaseIdentifier(a[i], b[i]);
+    if (result !== 0) return result;
+  }
+  return 0;
+}
+
+export function compareSemver(a, b) {
+  const av = parseSemver(a);
+  const bv = parseSemver(b);
+  if (!av || !bv) return compareString(String(a), String(b));
+
+  for (const key of ["major", "minor", "patch"]) {
+    if (av[key] > bv[key]) return 1;
+    if (av[key] < bv[key]) return -1;
+  }
+
+  return comparePrerelease(av.prerelease, bv.prerelease);
+}

--- a/test/check-update-version.test.mjs
+++ b/test/check-update-version.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { compareVersions } from "../lib/check-update.js";
+
+test("update checks compare prerelease versions with SemVer precedence", () => {
+  assert.equal(compareVersions("1.0.0-beta.10", "1.0.0-beta.9") > 0, true);
+  assert.equal(compareVersions("1.0.0-beta.20", "1.0.0-beta.19") > 0, true);
+  assert.equal(compareVersions("1.0.0-beta.1", "1.0.0-beta.alpha") < 0, true);
+  assert.equal(compareVersions("1.0.0", "1.0.0-rc.1") > 0, true);
+  assert.equal(compareVersions("1.0.0+build.2", "1.0.0+build.1"), 0);
+});


### PR DESCRIPTION
## Summary

- Replace custom prerelease string ordering with SemVer precedence for release tag selection.
- Reuse the same comparison in the runtime update checker.
- Add regression coverage for beta.9 -> beta.10, beta.19 -> beta.20, numeric vs non-numeric prerelease identifiers, and build metadata precedence.
- Broaden pre/post dry-run path filters so future lib and plugin test changes trigger validation.

## Validation

- Local: node --test .github/scripts/draft-cloud-plugin-release-notes.test.mjs
- Local: node --test test/*.test.mjs
- Local: git diff --check
- Local: pnpm pack --dry-run
- GitHub Actions: OpenClaw Cloud Plugin — Pre-Merge Dry Run #6 passed on c20bf70

No npm publish, tag creation, GitHub Release, or docs sync was run.