### PR TITLE
ci: harden cloud plugin release quality and recovery

### DIFF
--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -145,22 +145,29 @@ export function resolveCurrentRef(
   return "HEAD";
 }
 
-function listProductTags() {
-  try {
-    const remotes = git(["remote"]).split("\n").map((item) => item.trim()).filter(Boolean);
-    if (remotes.includes("origin")) {
-      git(["fetch", "--tags", "--force", "origin"], { stdio: ["ignore", "ignore", "ignore"] });
-    }
-  } catch {
-    warn("Failed to fetch tags from origin; using locally available tags.");
-  }
-
+function localProductTags() {
   return git(["tag", "--list", "v*"])
     .split("\n")
     .map((tag) => tag.trim())
     .filter(Boolean)
     .map((tag) => ({ tag, version: versionFromTag(tag) }))
     .filter((item) => item.version && parseSemver(item.version));
+}
+
+function listProductTags() {
+  const existingTags = localProductTags();
+  try {
+    const remotes = git(["remote"]).split("\n").map((item) => item.trim()).filter(Boolean);
+    if (remotes.includes("origin")) {
+      git(["fetch", "--tags", "--force", "origin"], { stdio: ["ignore", "ignore", "ignore"] });
+    }
+  } catch {
+    if (existingTags.length === 0) {
+      warn("Failed to fetch tags from origin; using locally available tags.");
+    }
+  }
+
+  return localProductTags();
 }
 
 export function findPreviousTag(targetVersion, currentTag) {

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -41,6 +41,24 @@ const CURRENT_TAG_PREFIX = "v";
 const RELEASE_NOTES_MARKER = "doc-agent-release-notes-json";
 const RELEASE_CATEGORY_ORDER = ["Added", "Improved", "Fixed"];
 const MAX_DRAFT_REPAIR_ATTEMPTS = 3;
+const MAX_RELEASE_ITEMS = 12;
+const MAX_TEXT_CN_CHARS = 180;
+const MAX_TEXT_EN_CHARS = 220;
+export const RELEASE_NOTE_LIMITS = Object.freeze({
+  max_items: MAX_RELEASE_ITEMS,
+  max_text_cn_characters: MAX_TEXT_CN_CHARS,
+  max_text_en_characters: MAX_TEXT_EN_CHARS,
+});
+export const RELEASE_FAULT_CASES = Object.freeze([
+  "none",
+  "mixed_language",
+  "missing_source_refs",
+  "missing_important_commit",
+  "invalid_source_ref",
+  "thirteen_items",
+  "too_long",
+  "manual_notes_missing_payload",
+]);
 export const RELEASE_NOTE_QUALITY_REQUEST = {
   schema: "memos.plugin.release_notes.quality_request.v1",
   candidate_count: 3,
@@ -239,8 +257,12 @@ function categoryHintForSubject(subject) {
   if (
     lower.startsWith("release:") ||
     /^chore(\([^)]+\))?:\s*(release|version|bump)\b/i.test(value) ||
+    /^(ci|build)(\([^)]+\))?:/i.test(value) ||
     /^test(\([^)]+\))?:/i.test(value) ||
-    /^docs(\([^)]+\))?:/i.test(value)
+    /^docs(\([^)]+\))?:/i.test(value) ||
+    /\b(release (tag|notes?|preview|workflow|metadata)|publish confirmation|semver[^:]*tag|tag[^:]*semver|npm publish)\b/i.test(
+      value,
+    )
   ) {
     return null;
   }
@@ -973,6 +995,43 @@ function languageIssuesFromReleaseItems(items) {
   return issues;
 }
 
+function readabilityIssuesFromReleaseItems(items) {
+  const issues = [];
+  if (items.length > MAX_RELEASE_ITEMS) {
+    issues.push({
+      field: "release_items",
+      item_count: items.length,
+      max_item_count: MAX_RELEASE_ITEMS,
+      reason: "Plugin changelog output must be grouped into concise product-facing bullets.",
+    });
+  }
+  for (const [index, item] of items.entries()) {
+    if (item.text_cn && item.text_cn.length > MAX_TEXT_CN_CHARS) {
+      issues.push({
+        index,
+        category: item.category,
+        field: "text_cn",
+        current_text: item.text_cn,
+        current_length: item.text_cn.length,
+        max_length: MAX_TEXT_CN_CHARS,
+        reason: "Chinese release-note text is too long for the Plugin tab.",
+      });
+    }
+    if (item.text_en && item.text_en.length > MAX_TEXT_EN_CHARS) {
+      issues.push({
+        index,
+        category: item.category,
+        field: "text_en",
+        current_text: item.text_en,
+        current_length: item.text_en.length,
+        max_length: MAX_TEXT_EN_CHARS,
+        reason: "English release-note text is too long for the Plugin tab.",
+      });
+    }
+  }
+  return issues;
+}
+
 function summarizeCoverageForValidation(coverage) {
   const value = coverage || {};
   return {
@@ -987,8 +1046,30 @@ function summarizeCoverageForValidation(coverage) {
 
 function validationReportFromPostprocessedDraft(draft) {
   const coverage = summarizeCoverageForValidation(draft?.coverage);
-  const languageIssues = Array.isArray(draft?.language_issues) ? draft.language_issues : [];
+  const releaseItems = Array.isArray(draft?.release_items) ? draft.release_items : [];
+  const languageIssues = languageIssuesFromReleaseItems(releaseItems);
+  const readabilityIssues = readabilityIssuesFromReleaseItems(releaseItems);
   const issues = [];
+  for (const [index, item] of releaseItems.entries()) {
+    const category = normalizeReleaseCategory(item?.category);
+    const textCn = String(item?.text_cn || "").trim();
+    const textEn = String(item?.text_en || "").trim();
+    const sourceRefs = normalizeSourceRefs(item?.source_refs);
+    if (!category || !textCn || !textEn) {
+      issues.push({
+        kind: "invalid_release_item",
+        index,
+        reason: "release item requires category, text_cn, text_en, and source_refs",
+      });
+    } else if (sourceRefs.length === 0) {
+      issues.push({
+        kind: "missing_source_refs",
+        index,
+        category,
+        reason: "release item must cite at least one real source_ref",
+      });
+    }
+  }
   for (const issue of languageIssues) {
     issues.push({
       kind: "language",
@@ -996,6 +1077,20 @@ function validationReportFromPostprocessedDraft(draft) {
       category: issue.category,
       field: issue.field,
       current_text: issue.current_text || "",
+      reason: issue.reason,
+    });
+  }
+  for (const issue of readabilityIssues) {
+    issues.push({
+      kind: "readability",
+      index: issue.index,
+      category: issue.category,
+      field: issue.field,
+      current_text: issue.current_text || "",
+      current_length: issue.current_length,
+      max_length: issue.max_length,
+      item_count: issue.item_count,
+      max_item_count: issue.max_item_count,
       reason: issue.reason,
     });
   }
@@ -1024,7 +1119,13 @@ function validationReportFromPostprocessedDraft(draft) {
     });
   }
 
-  const repairableKinds = new Set(["language", "missing_required_source"]);
+  const repairableKinds = new Set([
+    "language",
+    "readability",
+    "missing_source_refs",
+    "missing_required_source",
+    "invalid_source_ref",
+  ]);
   const repairable =
     issues.length > 0 &&
     issues.every((issue) => repairableKinds.has(issue.kind)) &&
@@ -1035,8 +1136,14 @@ function validationReportFromPostprocessedDraft(draft) {
     ok: Boolean(draft?.ok) && !draft?.needs_review && issues.length === 0,
     needs_review: Boolean(draft?.needs_review),
     repairable,
+    item_count: Array.isArray(draft?.release_items) ? draft.release_items.length : 0,
+    limits: RELEASE_NOTE_LIMITS,
     issue_count: issues.length,
     language_issue_count: languageIssues.length,
+    structure_issue_count: issues.filter((issue) =>
+      ["empty_release_items", "invalid_release_item", "missing_source_refs"].includes(issue.kind),
+    ).length,
+    readability_issue_count: readabilityIssues.length,
     invalid_item_ref_count: coverage.invalid_item_refs.length,
     missing_required_count: coverage.missing_required_count,
     issues,
@@ -1063,7 +1170,10 @@ function repairContextFromValidation({ draft, validationReport, repairAttempt, m
       "For language issues, edit only the affected text_cn/text_en field: text_cn must contain Chinese, text_en must contain no Chinese/CJK characters.",
       "Treat text_cn as the canonical wording first; text_en must be a faithful translation of text_cn, not an independently invented summary.",
       "Keep existing valid category and source_refs unchanged. Do not add source_refs that are not present in the evidence.",
+      "For missing_source_refs issues, attach one or more semantically matching refs from the evidence.",
       "For missing_required_source issues, add a concise product-facing item or attach the listed refs to a semantically matching existing item, using only the listed evidence.",
+      "For invalid_source_ref issues, replace fabricated refs with matching refs from the evidence; never invent a SHA or PR number.",
+      "For readability issues, group fragmented items and shorten only the flagged text while preserving facts and valid source_refs.",
       "When several valid repairs are possible, privately compare alternatives and return the candidate with the best evidence coverage, bilingual quality, and docs-preview readability.",
       "Return the same release_items schema with category, text_cn, text_en, and source_refs.",
     ],
@@ -1079,6 +1189,7 @@ function validationAttemptRecord({ stage, repairAttempt, draft, validationReport
     repairable: validationReport.repairable,
     issue_count: validationReport.issue_count,
     language_issue_count: validationReport.language_issue_count,
+    readability_issue_count: validationReport.readability_issue_count,
     missing_required_count: validationReport.missing_required_count,
     invalid_item_ref_count: validationReport.invalid_item_ref_count,
     coverage: validationReport.coverage,
@@ -1087,11 +1198,79 @@ function validationAttemptRecord({ stage, repairAttempt, draft, validationReport
   };
 }
 
+function cloneReleaseItems(draft) {
+  return (Array.isArray(draft?.release_items) ? draft.release_items : []).map((item) => ({
+    ...item,
+    source_refs: Array.isArray(item?.source_refs) ? [...item.source_refs] : [],
+  }));
+}
+
+function injectRawFaultCase(draft, evidence, faultCase) {
+  const items = cloneReleaseItems(draft);
+  if (items.length === 0) return draft;
+
+  if (faultCase === "missing_source_refs") {
+    items[0].source_refs = [];
+  } else if (faultCase === "invalid_source_ref") {
+    items[0].source_refs = ["deadbeef"];
+  } else if (faultCase === "missing_important_commit") {
+    const refsToRemove = new Set(
+      evidence?.release_note_guidance?.source_ref_category_hints?.[0]?.source_refs || [],
+    );
+    for (const item of items) {
+      item.source_refs = item.source_refs.filter((ref) => !refsToRemove.has(ref));
+    }
+  } else {
+    return draft;
+  }
+  return { ...draft, release_items: items };
+}
+
+function injectPostprocessedFaultCase(draft, faultCase) {
+  const items = cloneReleaseItems(draft);
+  if (items.length === 0) return draft;
+
+  if (faultCase === "mixed_language") {
+    items[0].text_en = `${items[0].text_en} 中文残留`;
+  } else if (faultCase === "thirteen_items") {
+    const seed = items[0];
+    while (items.length < RELEASE_NOTE_LIMITS.max_items + 1) {
+      const number = items.length + 1;
+      items.push({
+        ...seed,
+        text_cn: `${seed.text_cn}（故障注入条目 ${number}）`,
+        text_en: `${seed.text_en} (fault-injection item ${number})`,
+        source_refs: [...seed.source_refs],
+      });
+    }
+  } else if (faultCase === "too_long") {
+    items[0].text_cn =
+      `${items[0].text_cn}${"长".repeat(RELEASE_NOTE_LIMITS.max_text_cn_characters)}`;
+    items[0].text_en =
+      `${items[0].text_en} ${"long ".repeat(RELEASE_NOTE_LIMITS.max_text_en_characters)}`;
+  } else {
+    return draft;
+  }
+  return { ...draft, release_items: items };
+}
+
+export function injectReleaseFaultCase(draft, evidence, faultCase, { phase = "raw" } = {}) {
+  const value = String(faultCase || "none").trim() || "none";
+  if (!RELEASE_FAULT_CASES.includes(value)) {
+    fail(`Unknown release fault case: ${value}`);
+  }
+  if (value === "none" || value === "manual_notes_missing_payload") return draft;
+  return phase === "postprocess"
+    ? injectPostprocessedFaultCase(draft, value)
+    : injectRawFaultCase(draft, evidence, value);
+}
+
 export async function requestValidatedDraft(
   evidence,
   {
     requestImpl = requestDraft,
     maxRepairAttempts = MAX_DRAFT_REPAIR_ATTEMPTS,
+    faultCase = process.env.RELEASE_FAULT_CASE || "none",
   } = {},
 ) {
   let rawDraft = await requestImpl(evidence);
@@ -1100,7 +1279,16 @@ export async function requestValidatedDraft(
 
   for (let repairAttempt = 0; repairAttempt <= maxRepairAttempts; repairAttempt += 1) {
     const stage = repairAttempt === 0 ? "draft" : "repair";
-    const postprocessed = postprocessDraftFromEvidence(rawDraft, evidence);
+    const injectedRaw =
+      repairAttempt === 0
+        ? injectReleaseFaultCase(rawDraft, evidence, faultCase, { phase: "raw" })
+        : rawDraft;
+    let postprocessed = postprocessDraftFromEvidence(injectedRaw, evidence);
+    if (repairAttempt === 0) {
+      postprocessed = injectReleaseFaultCase(postprocessed, evidence, faultCase, {
+        phase: "postprocess",
+      });
+    }
     const validationReport = validationReportFromPostprocessedDraft(postprocessed);
     attempts.push(validationAttemptRecord({ stage, repairAttempt, draft: postprocessed, validationReport }));
 
@@ -1139,6 +1327,39 @@ export async function requestValidatedDraft(
   }
 
   return finalDraft;
+}
+
+export function qualityReportFromDraft(
+  draft,
+  { targetVersion = "", previousTag = "", currentTag = "", currentRef = "", faultCase = "none" } = {},
+) {
+  const validationReport =
+    draft?.validation_report || validationReportFromPostprocessedDraft(draft || {});
+  return {
+    schema: "memos.plugin.release_notes.quality_report.v1",
+    product_id: PRODUCT_ID,
+    repo: REPOSITORY,
+    target_version: displayVersion(targetVersion),
+    previous_tag: previousTag,
+    current_tag: currentTag,
+    current_ref: currentRef,
+    fault_case: faultCase || "none",
+    ok: Boolean(validationReport.ok),
+    needs_review: Boolean(validationReport.needs_review),
+    limits: RELEASE_NOTE_LIMITS,
+    item_count: Number(validationReport.item_count || draft?.release_items?.length || 0),
+    issue_count: Number(validationReport.issue_count || 0),
+    language_issue_count: Number(validationReport.language_issue_count || 0),
+    structure_issue_count: Number(validationReport.structure_issue_count || 0),
+    readability_issue_count: Number(validationReport.readability_issue_count || 0),
+    invalid_item_ref_count: Number(validationReport.invalid_item_ref_count || 0),
+    missing_required_count: Number(validationReport.missing_required_count || 0),
+    coverage: validationReport.coverage || summarizeCoverageForValidation(draft?.coverage),
+    issues: Array.isArray(validationReport.issues) ? validationReport.issues : [],
+    validation_attempt_count: Number(draft?.validation_attempt_count || 0),
+    repair_attempt_count: Number(draft?.repair_attempt_count || 0),
+    attempts: Array.isArray(draft?.repair_attempts) ? draft.repair_attempts : [],
+  };
 }
 
 function embeddedReleaseNotesPayload(items, coverage) {
@@ -1206,7 +1427,8 @@ export function postprocessDraftFromEvidence(draft, evidence) {
 
   const coverage = coverageFromReleaseItems(evidence, draft, items, index);
   const languageIssues = languageIssuesFromReleaseItems(items);
-  if (languageIssues.length > 0) {
+  const readabilityIssues = readabilityIssuesFromReleaseItems(items);
+  if (languageIssues.length > 0 || readabilityIssues.length > 0) {
     coverage.needs_review = true;
   }
   const { releaseCategories, docsCategories } = categoriesFromReleaseItems(items);
@@ -1230,8 +1452,11 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   if (languageIssues.length > 0) {
     warnings.push("release notes language validation failed; manual review is required");
   }
+  if (readabilityIssues.length > 0) {
+    warnings.push("release notes readability validation failed; the Plugin tab draft must be repaired before publishing");
+  }
 
-  return {
+  const result = {
     ...draft,
     ok: Boolean(items.length) && !coverage.needs_review,
     needs_review: Boolean(coverage.needs_review),
@@ -1241,8 +1466,13 @@ export function postprocessDraftFromEvidence(draft, evidence) {
     coverage,
     warnings,
     language_issues: languageIssues,
+    readability_issues: readabilityIssues,
     postprocess,
     release_notes_markdown: markdownFromReleaseItems(items, coverage),
+  };
+  return {
+    ...result,
+    validation_report: validationReportFromPostprocessedDraft(result),
   };
 }
 
@@ -1393,6 +1623,9 @@ export function validateManualNotes(notes) {
     if (CJK_RE.test(String(item.text_en || ""))) {
       fail("Every manual release-note item text_en must not contain Chinese/CJK characters.");
     }
+  }
+  if (readabilityIssuesFromReleaseItems(normalizedItems).length > 0) {
+    fail("Manual release-note items must stay concise enough for the Plugin tab preview.");
   }
   return text;
 }
@@ -1590,31 +1823,14 @@ export async function main() {
   if (!targetVersion) fail("RELEASE_VERSION is required.");
 
   const currentTag = process.env.RELEASE_TAG || `${CURRENT_TAG_PREFIX}${targetVersion}`;
+  const faultCase = String(process.env.RELEASE_FAULT_CASE || "none").trim() || "none";
+  if (!RELEASE_FAULT_CASES.includes(faultCase)) {
+    fail(`Unknown release fault case: ${faultCase}`);
+  }
   const notesPath =
     process.env.RELEASE_NOTES_FILE ||
     join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-release-notes.md`);
   mkdirSync(dirname(notesPath), { recursive: true });
-
-  const manualNotes = String(process.env.MANUAL_RELEASE_NOTES || "").trim();
-  if (manualNotes) {
-    const validManualNotes = ensureSourceHint(validateManualNotes(manualNotes));
-    const manualDraft = draftFromReleaseNotesMarkdown(validManualNotes);
-    const draftPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-release-notes-draft.json`);
-    const docsPreview = docsPreviewFromDraft(manualDraft, { targetVersion });
-    const docsPreviewPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-docs-preview.json`);
-    const docsPreviewMarkdownPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-docs-preview.md`);
-    writeFileSync(notesPath, validManualNotes, "utf8");
-    writeFileSync(draftPath, JSON.stringify(draftForInspection(manualDraft), null, 2), "utf8");
-    writeFileSync(docsPreviewPath, JSON.stringify(docsPreview, null, 2), "utf8");
-    writeFileSync(docsPreviewMarkdownPath, markdownFromDocsPreview(docsPreview), "utf8");
-    appendOutput("release_notes_file", notesPath);
-    appendOutput("draft_file", draftPath);
-    appendOutput("docs_preview_file", docsPreviewPath);
-    appendOutput("docs_preview_markdown_file", docsPreviewMarkdownPath);
-    appendOutput("draft_used", "false");
-    console.log(`Using manually provided release notes: ${notesPath}`);
-    return;
-  }
 
   const previousTag = findPreviousTag(targetVersion, currentTag);
   if (!previousTag) {
@@ -1626,25 +1842,120 @@ export async function main() {
   const evidencePath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-evidence.json`);
   writeFileSync(evidencePath, JSON.stringify(evidenceForInspection(evidence), null, 2), "utf8");
 
-  const draft = await requestValidatedDraft(evidence);
-  if (!draft.ok || draft.needs_review) {
-    fail(`Postprocessed release notes require review: ${JSON.stringify(draft.validation_report || draft.coverage || {})}`);
-  }
   const draftPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-release-notes-draft.json`);
-  const docsPreview = docsPreviewFromDraft(draft, { targetVersion });
   const docsPreviewPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-docs-preview.json`);
   const docsPreviewMarkdownPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-docs-preview.md`);
+  const qualityReportPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-quality-report.json`);
+
+  const suppliedManualNotes = String(process.env.MANUAL_RELEASE_NOTES || "").trim();
+  const manualNotes =
+    faultCase === "manual_notes_missing_payload"
+      ? "## Changelog\n\n### Added\n- Intentionally missing the hidden evidence payload."
+      : suppliedManualNotes;
+  let draftUsed = true;
+  let draft;
+
+  if (manualNotes) {
+    draftUsed = false;
+    try {
+      const validManualNotes = ensureSourceHint(validateManualNotes(manualNotes));
+      const postprocessed = postprocessDraftFromEvidence(
+        draftFromReleaseNotesMarkdown(validManualNotes),
+        evidence,
+      );
+      const validationReport = validationReportFromPostprocessedDraft(postprocessed);
+      draft = {
+        ...postprocessed,
+        validation_report: validationReport,
+        validation_attempt_count: 1,
+        repair_attempt_count: 0,
+        repair_attempts: [
+          validationAttemptRecord({
+            stage: "manual",
+            repairAttempt: 0,
+            draft: postprocessed,
+            validationReport,
+          }),
+        ],
+      };
+    } catch (error) {
+      const reason = cleanError(error?.message || error);
+      const validationReport = {
+        ok: false,
+        needs_review: true,
+        repairable: false,
+        issue_count: 1,
+        language_issue_count: 0,
+        structure_issue_count: 1,
+        readability_issue_count: 0,
+        invalid_item_ref_count: 0,
+        missing_required_count: 0,
+        item_count: 0,
+        limits: RELEASE_NOTE_LIMITS,
+        issues: [
+          {
+            kind:
+              faultCase === "manual_notes_missing_payload"
+                ? "manual_notes_missing_payload"
+                : "manual_notes_invalid",
+            reason,
+          },
+        ],
+        coverage: summarizeCoverageForValidation({ needs_review: true }),
+        postprocess: { applied: false, source: "manual_release_notes" },
+      };
+      draft = {
+        ok: false,
+        needs_review: true,
+        confidence: "manual",
+        release_items: [],
+        docs_categories: { cn: {}, en: {} },
+        coverage: validationReport.coverage,
+        warnings: [reason],
+        validation_report: validationReport,
+        validation_attempt_count: 1,
+        repair_attempt_count: 0,
+        repair_attempts: [
+          {
+            stage: "manual",
+            repair_attempt: 0,
+            ok: false,
+            needs_review: true,
+            repairable: false,
+            issue_count: 1,
+            issues: validationReport.issues,
+          },
+        ],
+        release_notes_markdown: manualNotes,
+      };
+    }
+  } else {
+    draft = await requestValidatedDraft(evidence, { faultCase });
+  }
+
+  const docsPreview = docsPreviewFromDraft(draft, { targetVersion });
+  const qualityReport = qualityReportFromDraft(draft, {
+    targetVersion,
+    previousTag,
+    currentTag,
+    currentRef,
+    faultCase,
+  });
   writeFileSync(draftPath, JSON.stringify(draftForInspection(draft), null, 2), "utf8");
   writeFileSync(docsPreviewPath, JSON.stringify(docsPreview, null, 2), "utf8");
   writeFileSync(docsPreviewMarkdownPath, markdownFromDocsPreview(docsPreview), "utf8");
-  writeFileSync(notesPath, ensureSourceHint(draft.release_notes_markdown), "utf8");
+  writeFileSync(qualityReportPath, JSON.stringify(qualityReport, null, 2), "utf8");
+  if (String(draft.release_notes_markdown || "").trim()) {
+    writeFileSync(notesPath, ensureSourceHint(draft.release_notes_markdown), "utf8");
+  }
 
   appendOutput("release_notes_file", notesPath);
   appendOutput("evidence_file", evidencePath);
   appendOutput("draft_file", draftPath);
   appendOutput("docs_preview_file", docsPreviewPath);
   appendOutput("docs_preview_markdown_file", docsPreviewMarkdownPath);
-  appendOutput("draft_used", "true");
+  appendOutput("quality_report_file", qualityReportPath);
+  appendOutput("draft_used", String(draftUsed));
   appendOutput("previous_tag", previousTag);
   appendOutput("current_tag", currentTag);
   appendOutput("current_ref", currentRef);
@@ -1652,14 +1963,20 @@ export async function main() {
   appendOutput("missing_required_count", String(draft.coverage?.missing_required_count ?? ""));
   appendOutput("validation_attempt_count", String(draft.validation_attempt_count ?? ""));
   appendOutput("repair_attempt_count", String(draft.repair_attempt_count ?? ""));
+  appendOutput("fault_case", faultCase);
 
-  console.log(`Drafted release notes with configured service: ${notesPath}`);
+  console.log(`${draftUsed ? "Drafted" : "Validated manual"} release notes: ${notesPath}`);
   console.log(`Previous tag: ${previousTag}`);
   console.log(`Current tag: ${currentTag}`);
   console.log(`Current evidence ref: ${currentRef}`);
+  console.log(`Fault case: ${faultCase}`);
   console.log(`Coverage: ${JSON.stringify(draft.coverage || {})}`);
   console.log(`Validation attempts: ${draft.validation_attempt_count ?? ""}`);
   console.log(`Repair attempts: ${draft.repair_attempt_count ?? ""}`);
+
+  if (!draft.ok || draft.needs_review) {
+    fail(`Postprocessed release notes require review: ${JSON.stringify(draft.validation_report || draft.coverage || {})}`);
+  }
 }
 
 const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -147,7 +147,10 @@ export function resolveCurrentRef(
 
 function listProductTags() {
   try {
-    git(["fetch", "--tags", "--force", "origin"], { stdio: ["ignore", "ignore", "ignore"] });
+    const remotes = git(["remote"]).split("\n").map((item) => item.trim()).filter(Boolean);
+    if (remotes.includes("origin")) {
+      git(["fetch", "--tags", "--force", "origin"], { stdio: ["ignore", "ignore", "ignore"] });
+    }
   } catch {
     warn("Failed to fetch tags from origin; using locally available tags.");
   }

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -337,6 +337,7 @@ export function draftForInspection(draft) {
     needs_review: Boolean(draft?.needs_review),
     confidence: draft?.confidence || "",
     release_items: Array.isArray(draft?.release_items) ? draft.release_items : [],
+    docs_categories: draft?.docs_categories || { cn: {}, en: {} },
     coverage: {
       needs_review: Boolean(draft?.coverage?.needs_review),
       required_count: Number(draft?.coverage?.required_count || 0),
@@ -380,9 +381,9 @@ function normalizeReleaseCategory(value) {
 
 function normalizeSourceRef(value) {
   const text = String(value || "").trim().replace(/^[`[(\s]+|[`)\],.;\s]+$/g, "");
-  if (/^\d{2,}$/.test(text)) return `#${text}`;
   if (/^#\d+$/.test(text)) return text;
   if (/^[a-fA-F0-9]{7,40}$/.test(text)) return text.toLowerCase();
+  if (/^\d{2,}$/.test(text)) return `#${text}`;
   return "";
 }
 
@@ -465,6 +466,308 @@ function groupKeysForItem(item, refToGroup) {
     if (!keys.includes(key)) keys.push(key);
   }
   return keys;
+}
+
+function subjectsForItem(item, index) {
+  return groupKeysForItem(item, index.refToGroup)
+    .map((key) => index.groups.get(key)?.subject || "")
+    .filter(Boolean)
+    .join(" ");
+}
+
+function evidenceTextForItem(item, index) {
+  return `${subjectsForItem(item, index)}\n${item.text_cn || ""}\n${item.text_en || ""}`;
+}
+
+function knownReleaseItemsForItem(item, index, { allowSplit = true } = {}) {
+  if (allowSplit && item.source_refs.length > 1) {
+    const splitItems = item.source_refs.flatMap((ref) =>
+      knownReleaseItemsForItem({ ...item, source_refs: [ref] }, index, { allowSplit: false }),
+    );
+    const changedByEvidence = splitItems.some(
+      (split) =>
+        split.category !== item.category ||
+        split.text_cn !== item.text_cn ||
+        split.text_en !== item.text_en,
+    );
+    if (changedByEvidence) return dedupeReleaseItems(splitItems);
+  }
+
+  const subjectBlob = subjectsForItem(item, index).toLowerCase();
+  const blob = evidenceTextForItem(item, index).toLowerCase();
+  const refs = [...item.source_refs];
+  const rewrite = (category, textCn, textEn) => ({
+    ...item,
+    category,
+    text_cn: textCn,
+    text_en: textEn,
+    source_refs: refs,
+  });
+
+  const semverPattern = /semver|prerelease|previous tag|compare release tags|beta\.10|beta\.20|update checker|check-update/;
+  const configUpdatePattern = /config ui update check|update check|version status|host-specific update|restart command|copy.*restart/;
+  const memorySourcePattern = /memos_source|memory source|platform|windows|macos|linux|darwin/;
+  const hookPattern = /activation hooks|capability declaration|hook policy|before_prompt_build|recall hook|add memory hook|hook registration/;
+  const recallFilterPattern = /recall filter|payload sanit|query strip|prompt sanit|memory pollution/;
+  const toolMemoryPattern = /tool memory|tool_memories|assistant\.tool_calls|toolresult/;
+  const memoryFilteringPattern = /buildmemorysections|memory section handling|filtering logic|relevance-threshold|relevance threshold/;
+  const systemNotePattern = /system note|leading system notes|interruption notes/;
+  const systemEventSkipPattern = /implement system event detection|skip processing for heartbeat|heartbeat and command events|heartbeat polls|system commands/;
+  const systemEventRefactorPattern = /refactor system event detection|extend system command detection|system-command detection|internal prompt patterns/;
+  const telemetryPattern = /telemetry credentials|memos_arms|arms|rum|observability|generate telemetry credentials/;
+  const systemPromptPattern =
+    /system prompt detection and handling|scheduled task|scheduled reminder|background command|system event|isforcedsystemmessage|system prompt/;
+
+  if (/recall hook registration.*before_prompt_build|before_prompt_build.*newer openclaw|version compatibility/.test(subjectBlob)) {
+    return [
+      rewrite(
+        "Added",
+        "**Recall Hook 兼容新版 OpenClaw**：当宿主版本支持阶段化 Hook 时，召回逻辑自动迁移至 `before_prompt_build`，旧版宿主继续兼容 `before_agent_start`。",
+        "**Recall Hook compatibility for modern OpenClaw hosts**: Moves recall logic to `before_prompt_build` on hosts that support phased hooks while keeping `before_agent_start` compatibility for legacy hosts.",
+      ),
+    ];
+  }
+
+  if (systemEventSkipPattern.test(subjectBlob)) {
+    return [
+      rewrite(
+        "Added",
+        "**系统事件自动跳过**：召回与写入阶段自动识别并跳过心跳探测、系统命令等系统事件，保持记忆数据纯净。",
+        "**Automatic system-event skipping**: Detects and skips heartbeat polls, system commands, and other system events during recall and write phases to keep memory records clean.",
+      ),
+    ];
+  }
+
+  if (toolMemoryPattern.test(subjectBlob)) {
+    const items = [
+      rewrite(
+        "Added",
+        "**工具记忆全链路支持**：召回阶段注入 `<tool_memories>`，写入阶段支持 `assistant.tool_calls` 与 `toolResult` 消息转换，统一写入 MemOS 标准消息结构。",
+        "**End-to-end Tool Memory support**: Injects `<tool_memories>` during recall and converts `assistant.tool_calls` plus `toolResult` messages into the standard MemOS message structure during write.",
+      ),
+    ];
+    if (memoryFilteringPattern.test(subjectBlob)) {
+      items.push(
+        rewrite(
+          "Improved",
+          "**记忆过滤逻辑精简**：整合记忆片段构建中的重复过滤判断，降低无关内容进入上下文的概率。",
+          "**Memory filtering cleanup**: Consolidates duplicated filtering logic while building memory sections to reduce irrelevant context injection.",
+        ),
+      );
+    }
+    return items;
+  }
+
+  if (systemNotePattern.test(subjectBlob)) {
+    return [
+      rewrite(
+        "Added",
+        "**System Note 前缀自动剥离**：自动剔除上轮 Agent 中断提示词，提升召回查询与入库数据准确性。",
+        "**System Note prefix stripping**: Removes previous-run interruption notes to improve recall queries and stored-memory accuracy.",
+      ),
+    ];
+  }
+
+  if (/extend system command detection|include 'clear' command|internal prompt patterns/.test(subjectBlob)) {
+    return [
+      rewrite(
+        "Improved",
+        "**内部提示识别增强**：扩展 `clear` 命令和内部提示模式识别，减少系统命令类内容进入记忆流程。",
+        "**Internal prompt detection**: Extends `clear` command and internal prompt pattern detection to keep system-command content out of the memory flow.",
+      ),
+    ];
+  }
+
+  if (systemEventRefactorPattern.test(subjectBlob)) {
+    return [
+      rewrite(
+        "Improved",
+        "**系统事件检测重构**：提取心跳、系统命令和内部提示识别逻辑，并降低正常用户消息误判概率。",
+        "**System-event detection refactor**: Extracts heartbeat, system-command, and internal-prompt detection helpers to reduce false positives on normal user messages.",
+      ),
+    ];
+  }
+
+  const subjectFirstRules = [
+    [semverPattern, () => [
+      rewrite(
+        "Fixed",
+        "**版本比较边界修复**：使用标准 SemVer precedence 选择上一版本并检测更新，避免 beta.10、beta.20 等预发布版本被错误排序。",
+        "**Version comparison boundaries**: Uses SemVer precedence for previous-tag selection and update checks so beta.10, beta.20, and similar prereleases sort correctly.",
+      ),
+    ]],
+    [configUpdatePattern, () => [
+      rewrite(
+        "Improved",
+        "**配置页新增更新检查**：可查看版本状态，并复制对应宿主的更新重启命令。",
+        "**Update checks in settings**: Shows version status and lets users copy host-specific update or restart commands.",
+      ),
+    ]],
+    [memorySourcePattern, () => [
+      rewrite(
+        "Added",
+        "**跨平台记忆来源识别**：自动区分 Windows、macOS、Linux 的记忆数据。",
+        "**Platform-aware memory source labeling**: Distinguishes Windows, macOS, and Linux memory data automatically.",
+      ),
+    ]],
+  ];
+
+  for (const [pattern, buildItems] of subjectFirstRules) {
+    if (pattern.test(subjectBlob)) return buildItems();
+  }
+
+  if (hookPattern.test(subjectBlob)) {
+    if (/before_prompt_build|hook registration|registration/.test(subjectBlob)) {
+      return [
+        rewrite(
+          "Fixed",
+          "**Hook 注册兼容性修复**：在支持的 OpenClaw 宿主上正确注册回忆 hook，避免提示构建阶段缺失记忆召回。",
+          "**Hook registration compatibility**: Registers recall hooks correctly on supported OpenClaw hosts so memory recall is available during prompt construction.",
+        ),
+      ];
+    }
+    return [
+      rewrite(
+        "Added",
+        "**插件 Hook 能力声明**：补充插件激活与记忆相关 hook 声明，让宿主能够按权限策略启用云端记忆能力。",
+        "**Plugin hook capability declarations**: Adds activation and memory hook declarations so hosts can enable cloud memory through the permission policy.",
+      ),
+    ];
+  }
+
+  if (recallFilterPattern.test(subjectBlob)) {
+    return [
+      rewrite(
+        "Improved",
+        "**召回过滤与提示清洗优化**：增强召回请求和提示内容清洗，降低系统消息或无关参数进入记忆流程的概率。",
+        "**Recall filtering and prompt sanitization**: Improves recall-request and prompt cleanup to reduce system-message or irrelevant-parameter leakage into memory flows.",
+      ),
+    ];
+  }
+
+  if (telemetryPattern.test(subjectBlob)) {
+    return [
+      rewrite(
+        "Improved",
+        "**遥测凭据打包校验**：发布前校验遥测凭据生成状态，避免半配置密钥导致观测能力缺失或包内容不完整。",
+        "**Telemetry credential packaging**: Validates telemetry credential generation before release to avoid partial secret configuration and incomplete observability packaging.",
+      ),
+    ];
+  }
+
+  if (systemPromptPattern.test(subjectBlob) || systemPromptPattern.test(blob)) {
+    const items = [];
+    if (
+      /system prompt detection and handling|scheduled task|scheduled reminder|background command|system event|isforcedsystemmessage/.test(
+        blob,
+      )
+    ) {
+      items.push(
+        rewrite(
+          "Improved",
+          "**系统事件过滤增强**：自动跳过定时任务、计划提醒和后台命令结果，减少记忆污染。",
+          "**System-event filtering**: Skips scheduled tasks, reminders, and background command results to keep memory cleaner.",
+        ),
+      );
+    }
+    if (/system prompt detection and handling|system prompt|single-line|flattened|false positive|prompt detection/.test(blob)) {
+      items.push(
+        rewrite(
+          "Improved",
+          "**系统提示识别优化**：兼容单行压缩内容并降低普通消息误判概率。",
+          "**System prompt detection**: Supports flattened single-line prompts and reduces false positives on regular messages.",
+        ),
+      );
+    }
+    if (items.length > 0) return items;
+  }
+
+  if (semverPattern.test(blob)) {
+    return [
+      rewrite(
+        "Fixed",
+        "**版本比较边界修复**：使用标准 SemVer precedence 选择上一版本并检测更新，避免 beta.10、beta.20 等预发布版本被错误排序。",
+        "**Version comparison boundaries**: Uses SemVer precedence for previous-tag selection and update checks so beta.10, beta.20, and similar prereleases sort correctly.",
+      ),
+    ];
+  }
+
+  if (configUpdatePattern.test(blob)) {
+    return [
+      rewrite(
+        "Improved",
+        "**配置页新增更新检查**：可查看版本状态，并复制对应宿主的更新重启命令。",
+        "**Update checks in settings**: Shows version status and lets users copy host-specific update or restart commands.",
+      ),
+    ];
+  }
+
+  if (memorySourcePattern.test(blob)) {
+    return [
+      rewrite(
+        "Added",
+        "**跨平台记忆来源识别**：自动区分 Windows、macOS、Linux 的记忆数据。",
+        "**Platform-aware memory source labeling**: Distinguishes Windows, macOS, and Linux memory data automatically.",
+      ),
+    ];
+  }
+
+  if (hookPattern.test(blob)) {
+    if (/before_prompt_build|hook registration|registration/.test(blob)) {
+      return [
+        rewrite(
+          "Fixed",
+          "**Hook 注册兼容性修复**：在支持的 OpenClaw 宿主上正确注册回忆 hook，避免提示构建阶段缺失记忆召回。",
+          "**Hook registration compatibility**: Registers recall hooks correctly on supported OpenClaw hosts so memory recall is available during prompt construction.",
+        ),
+      ];
+    }
+    return [
+      rewrite(
+        "Added",
+        "**插件 Hook 能力声明**：补充插件激活与记忆相关 hook 声明，让宿主能够按权限策略启用云端记忆能力。",
+        "**Plugin hook capability declarations**: Adds activation and memory hook declarations so hosts can enable cloud memory through the permission policy.",
+      ),
+    ];
+  }
+
+  if (recallFilterPattern.test(blob)) {
+    return [
+      rewrite(
+        "Improved",
+        "**召回过滤与提示清洗优化**：增强召回请求和提示内容清洗，降低系统消息或无关参数进入记忆流程的概率。",
+        "**Recall filtering and prompt sanitization**: Improves recall-request and prompt cleanup to reduce system-message or irrelevant-parameter leakage into memory flows.",
+      ),
+    ];
+  }
+
+  if (telemetryPattern.test(blob)) {
+    return [
+      rewrite(
+        "Improved",
+        "**遥测凭据打包校验**：发布前校验遥测凭据生成状态，避免半配置密钥导致观测能力缺失或包内容不完整。",
+        "**Telemetry credential packaging**: Validates telemetry credential generation before release to avoid partial secret configuration and incomplete observability packaging.",
+      ),
+    ];
+  }
+
+  return [item];
+}
+
+function expandKnownReleaseItems(items, index) {
+  let expandedKnownItems = 0;
+  const expanded = [];
+  for (const item of items) {
+    const knownItems = knownReleaseItemsForItem(item, index);
+    if (knownItems.length !== 1 || knownItems[0] !== item) {
+      expandedKnownItems += Math.max(1, knownItems.length);
+    }
+    expanded.push(...knownItems);
+  }
+  return {
+    items: dedupeReleaseItems(expanded),
+    expandedKnownItems,
+  };
 }
 
 function bestHintCategoryForItem(item, index) {
@@ -870,6 +1173,8 @@ export function postprocessDraftFromEvidence(draft, evidence) {
       return { ...item, category };
     }),
   );
+  const expanded = expandKnownReleaseItems(items, index);
+  items = expanded.items;
 
   const coverage = coverageFromReleaseItems(evidence, draft, items, index);
   const languageIssues = languageIssuesFromReleaseItems(items);
@@ -882,15 +1187,17 @@ export function postprocessDraftFromEvidence(draft, evidence) {
     removed_duplicate_source_refs: deduped.removedDuplicateRefs,
     dropped_empty_source_items: deduped.droppedItems,
     reclassified_items: reclassifiedItems,
+    expanded_known_items: expanded.expandedKnownItems,
     final_item_count: items.length,
   };
   const warnings = Array.isArray(draft.warnings) ? [...draft.warnings] : [];
   if (
     postprocess.removed_duplicate_source_refs > 0 ||
     postprocess.dropped_empty_source_items > 0 ||
-    postprocess.reclassified_items > 0
+    postprocess.reclassified_items > 0 ||
+    postprocess.expanded_known_items > 0
   ) {
-    warnings.push("release notes were postprocessed to dedupe source_refs and apply evidence category hints");
+    warnings.push("release notes were postprocessed to dedupe source_refs, apply evidence category hints, and normalize known cloud plugin topics");
   }
   if (languageIssues.length > 0) {
     warnings.push("release notes language validation failed; manual review is required");
@@ -911,21 +1218,133 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   };
 }
 
+function previewDateFromPublishedAt(value) {
+  const text = String(value || "").trim();
+  if (!text) return "<GitHub Release published_at>";
+  const date = new Date(text);
+  if (Number.isNaN(date.getTime())) return "<GitHub Release published_at>";
+  return date.toISOString().slice(0, 10);
+}
+
+export function docsPreviewFromDraft(draft, { targetVersion, publishedAt = "" } = {}) {
+  const version = displayVersion(targetVersion || draft?.target_version || "");
+  const date = previewDateFromPublishedAt(publishedAt);
+  const docsCategories = draft?.docs_categories || { cn: {}, en: {} };
+  const buildEntry = (locale) => ({
+    name: version,
+    date,
+    products: {
+      plugin: Object.fromEntries(
+        Object.entries(docsCategories[locale] || {}).map(([category, items]) => [
+          category,
+          [
+            {
+              type: locale === "cn" ? PRODUCT_TITLE.zh : PRODUCT_TITLE.en,
+              changedInfo: items,
+            },
+          ],
+        ]),
+      ),
+    },
+  });
+  return {
+    schema: "memos.plugin.docs_preview.v1",
+    product_id: PRODUCT_ID,
+    repo: REPOSITORY,
+    version,
+    date,
+    date_source: publishedAt ? "provided published_at" : "GitHub Release published_at at publish time",
+    docs_files: {
+      cn: "content/cn/plugin-changelog.yml",
+      en: "content/en/plugin-changelog.yml",
+    },
+    entries: {
+      cn: buildEntry("cn"),
+      en: buildEntry("en"),
+    },
+  };
+}
+
+export function markdownFromDocsPreview(preview) {
+  const lines = [
+    "# MemOS-Docs Plugin Changelog Preview",
+    "",
+    `- product_id: ${preview.product_id}`,
+    `- version: ${preview.version}`,
+    `- date: ${preview.date}`,
+    `- zh file: ${preview.docs_files.cn}`,
+    `- en file: ${preview.docs_files.en}`,
+  ];
+  for (const [locale, title] of [
+    ["cn", "中文预览"],
+    ["en", "English Preview"],
+  ]) {
+    lines.push("");
+    lines.push(`## ${title}`);
+    const plugin = preview.entries[locale]?.products?.plugin || {};
+    const categories = Object.keys(plugin);
+    if (categories.length === 0) {
+      lines.push("");
+      lines.push("- No plugin changelog items would be rendered.");
+      continue;
+    }
+    for (const category of categories) {
+      lines.push("");
+      lines.push(`### ${category}`);
+      for (const group of plugin[category] || []) {
+        lines.push("");
+        lines.push(`- type: ${group.type}`);
+        for (const item of group.changedInfo || []) {
+          lines.push(`  - ${item}`);
+        }
+      }
+    }
+  }
+  return `${lines.join("\n").trim()}\n`;
+}
+
+function releaseNotesPayloadFromMarkdown(text) {
+  const match = text.match(/<!--\s*doc-agent-release-notes-json\s*\n([\s\S]*?)\n-->/);
+  if (!match) {
+    fail("Manual release notes must include the doc-agent-release-notes-json evidence block.");
+  }
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    fail("Manual release notes contain invalid doc-agent-release-notes-json.");
+  }
+}
+
+function draftFromReleaseNotesMarkdown(notes) {
+  const payload = releaseNotesPayloadFromMarkdown(notes);
+  const items = Array.isArray(payload?.items) ? payload.items.map(normalizeReleaseItem).filter(Boolean) : [];
+  const coverage = payload?.coverage || {};
+  const { releaseCategories, docsCategories } = categoriesFromReleaseItems(items);
+  return {
+    ok: items.length > 0 && coverage.needs_review === false,
+    needs_review: coverage.needs_review !== false,
+    confidence: "manual",
+    release_items: items,
+    release_categories: releaseCategories,
+    docs_categories: docsCategories,
+    coverage,
+    warnings: [],
+    language_issues: languageIssuesFromReleaseItems(items),
+    postprocess: {
+      applied: false,
+      source: "manual_release_notes",
+      final_item_count: items.length,
+    },
+    release_notes_markdown: notes,
+  };
+}
+
 export function validateManualNotes(notes) {
   const text = String(notes || "").trim();
   if (!/^## Changelog\s*$/m.test(text)) {
     fail("Manual release notes must contain a '## Changelog' heading.");
   }
-  const match = text.match(/<!--\s*doc-agent-release-notes-json\s*\n([\s\S]*?)\n-->/);
-  if (!match) {
-    fail("Manual release notes must include the doc-agent-release-notes-json evidence block.");
-  }
-  let payload;
-  try {
-    payload = JSON.parse(match[1]);
-  } catch {
-    fail("Manual release notes contain invalid doc-agent-release-notes-json.");
-  }
+  const payload = releaseNotesPayloadFromMarkdown(text);
   if (!Array.isArray(payload?.items) || payload.items.length === 0) {
     fail("Manual release notes evidence block must contain non-empty items.");
   }
@@ -948,6 +1367,10 @@ export function validateManualNotes(notes) {
 
 function isRetryableStatus(status) {
   return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function hasStructuredDraftItems(payload) {
+  return Array.isArray(payload?.release_items) && payload.release_items.map(normalizeReleaseItem).some(Boolean);
 }
 
 function cleanError(value) {
@@ -1086,6 +1509,12 @@ export async function requestDraft(
         const coverage = payload.coverage ? JSON.stringify(payload.coverage) : "";
         const warnings = Array.isArray(payload.warnings) ? payload.warnings.join("; ") : "";
         const message = `Release notes draft needs review. ${coverage} ${warnings}`.trim();
+        if (hasStructuredDraftItems(payload)) {
+          warn(
+            `${message} Continuing with local validation and repair because the draft service returned structured release_items.`,
+          );
+          return payload;
+        }
         if (serverAttempts.length >= 3) {
           await reportFailure({
             evidence,
@@ -1100,7 +1529,7 @@ export async function requestDraft(
         }
         fail(message);
       }
-      if (!String(payload.release_notes_markdown || "").trim()) {
+      if (!String(payload.release_notes_markdown || "").trim() && !hasStructuredDraftItems(payload)) {
         fail("Release-notes draft service returned an empty release_notes_markdown.");
       }
       return payload;
@@ -1136,8 +1565,20 @@ export async function main() {
 
   const manualNotes = String(process.env.MANUAL_RELEASE_NOTES || "").trim();
   if (manualNotes) {
-    writeFileSync(notesPath, ensureSourceHint(validateManualNotes(manualNotes)), "utf8");
+    const validManualNotes = ensureSourceHint(validateManualNotes(manualNotes));
+    const manualDraft = draftFromReleaseNotesMarkdown(validManualNotes);
+    const draftPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-release-notes-draft.json`);
+    const docsPreview = docsPreviewFromDraft(manualDraft, { targetVersion });
+    const docsPreviewPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-docs-preview.json`);
+    const docsPreviewMarkdownPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-docs-preview.md`);
+    writeFileSync(notesPath, validManualNotes, "utf8");
+    writeFileSync(draftPath, JSON.stringify(draftForInspection(manualDraft), null, 2), "utf8");
+    writeFileSync(docsPreviewPath, JSON.stringify(docsPreview, null, 2), "utf8");
+    writeFileSync(docsPreviewMarkdownPath, markdownFromDocsPreview(docsPreview), "utf8");
     appendOutput("release_notes_file", notesPath);
+    appendOutput("draft_file", draftPath);
+    appendOutput("docs_preview_file", docsPreviewPath);
+    appendOutput("docs_preview_markdown_file", docsPreviewMarkdownPath);
     appendOutput("draft_used", "false");
     console.log(`Using manually provided release notes: ${notesPath}`);
     return;
@@ -1158,12 +1599,19 @@ export async function main() {
     fail(`Postprocessed release notes require review: ${JSON.stringify(draft.validation_report || draft.coverage || {})}`);
   }
   const draftPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-release-notes-draft.json`);
+  const docsPreview = docsPreviewFromDraft(draft, { targetVersion });
+  const docsPreviewPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-docs-preview.json`);
+  const docsPreviewMarkdownPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-docs-preview.md`);
   writeFileSync(draftPath, JSON.stringify(draftForInspection(draft), null, 2), "utf8");
+  writeFileSync(docsPreviewPath, JSON.stringify(docsPreview, null, 2), "utf8");
+  writeFileSync(docsPreviewMarkdownPath, markdownFromDocsPreview(docsPreview), "utf8");
   writeFileSync(notesPath, ensureSourceHint(draft.release_notes_markdown), "utf8");
 
   appendOutput("release_notes_file", notesPath);
   appendOutput("evidence_file", evidencePath);
   appendOutput("draft_file", draftPath);
+  appendOutput("docs_preview_file", docsPreviewPath);
+  appendOutput("docs_preview_markdown_file", docsPreviewMarkdownPath);
   appendOutput("draft_used", "true");
   appendOutput("previous_tag", previousTag);
   appendOutput("current_tag", currentTag);

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -420,7 +420,18 @@ function appendOutput(name, value) {
 
 export function ensureSourceHint(notes) {
   const hint = `<!-- doc-agent: source-id=${PRODUCT_ID} -->`;
-  return notes.includes("doc-agent: source-id=") ? notes : `${notes.trim()}\n\n${hint}\n`;
+  const sourceIds = [
+    ...String(notes || "").matchAll(
+      /<!--\s*doc-agent:\s*source-id=([A-Za-z0-9._-]+)\s*-->/g,
+    ),
+  ].map((match) => match[1]);
+  if (sourceIds.length === 0) return `${notes.trim()}\n\n${hint}\n`;
+  if (sourceIds.length !== 1 || sourceIds[0] !== PRODUCT_ID) {
+    fail(
+      `Release notes must contain exactly one Doc Agent source id ${PRODUCT_ID}; found ${sourceIds.join(", ") || "none"}.`,
+    );
+  }
+  return notes;
 }
 
 function normalizeReleaseCategory(value) {

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -189,9 +189,15 @@ function listProductTags() {
 }
 
 export function findPreviousTag(targetVersion, currentTag) {
+  const target = parseSemver(targetVersion);
+  const stableTarget = Boolean(target && target.prerelease.length === 0);
   const candidates = listProductTags()
     .filter((item) => item.tag !== currentTag)
     .filter((item) => compareSemver(item.version, targetVersion) < 0)
+    // Prereleases never create a formal Docs entry. A stable release therefore
+    // has to summarize everything since the previous stable release instead of
+    // starting after the latest beta/rc and silently omitting those changes.
+    .filter((item) => !stableTarget || parseSemver(item.version)?.prerelease.length === 0)
     .sort((a, b) => compareSemver(b.version, a.version));
   return candidates[0]?.tag || "";
 }

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -251,11 +251,12 @@ function refsForGuidance(commit) {
   return refs;
 }
 
-function categoryHintForSubject(subject) {
+function isReleaseNoiseSubject(subject) {
   const value = String(subject || "");
   const lower = value.toLowerCase();
-  if (
+  return (
     lower.startsWith("release:") ||
+    /^v?\d+\.\d+\.\d+(?:-[0-9a-z.-]+)?$/i.test(value.trim()) ||
     /^chore(\([^)]+\))?:\s*(release|version|bump)\b/i.test(value) ||
     /^(ci|build)(\([^)]+\))?:/i.test(value) ||
     /^test(\([^)]+\))?:/i.test(value) ||
@@ -263,7 +264,12 @@ function categoryHintForSubject(subject) {
     /\b(release (tag|notes?|preview|workflow|metadata)|publish confirmation|semver[^:]*tag|tag[^:]*semver|npm publish)\b/i.test(
       value,
     )
-  ) {
+  );
+}
+
+function categoryHintForSubject(subject) {
+  const value = String(subject || "");
+  if (isReleaseNoiseSubject(value)) {
     return null;
   }
   if (/^(feat|feature|add)(\([^)]+\))?:|^add\s+/i.test(value)) {
@@ -489,9 +495,13 @@ function buildSourceRefIndex(evidence) {
   const refToGroup = new Map();
   const groups = new Map();
   const knownRefs = new Set();
+  const excludedRefs = new Set();
 
   for (const commit of evidence?.commits || []) {
-    for (const ref of refsForCommit(commit)) knownRefs.add(ref);
+    for (const ref of refsForCommit(commit)) {
+      knownRefs.add(ref);
+      if (isReleaseNoiseSubject(commit?.subject)) excludedRefs.add(ref);
+    }
   }
 
   for (const hint of evidence?.release_note_guidance?.source_ref_category_hints || []) {
@@ -512,7 +522,7 @@ function buildSourceRefIndex(evidence) {
     });
   }
 
-  return { refToGroup, groups, knownRefs };
+  return { refToGroup, groups, knownRefs, excludedRefs };
 }
 
 function groupKeyForRef(ref, refToGroup) {
@@ -896,6 +906,25 @@ function dedupeSourceRefsByBestCategory(items, index) {
     filtered.push({ ...item, source_refs: refs });
   }
   return { items: filtered, removedDuplicateRefs, droppedItems };
+}
+
+function removeReleaseNoiseRefs(items, index) {
+  let removedNoiseRefs = 0;
+  let droppedNoiseItems = 0;
+  const filtered = [];
+  for (const item of items) {
+    const refs = item.source_refs.filter((ref) => {
+      if (!index.excludedRefs.has(ref)) return true;
+      removedNoiseRefs += 1;
+      return false;
+    });
+    if (refs.length === 0) {
+      droppedNoiseItems += 1;
+      continue;
+    }
+    filtered.push({ ...item, source_refs: refs });
+  }
+  return { items: filtered, removedNoiseRefs, droppedNoiseItems };
 }
 
 function dedupeReleaseItems(items) {
@@ -1416,8 +1445,9 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   if (inputItems.length === 0) return draft;
 
   const index = buildSourceRefIndex(evidence);
+  const noiseFiltered = removeReleaseNoiseRefs(inputItems, index);
   let reclassifiedItems = 0;
-  let items = inputItems.map((item) => {
+  let items = noiseFiltered.items.map((item) => {
     const hintedCategory = bestHintCategoryForItem(item, index);
     const category = hintedCategory || item.category;
     if (category !== item.category) reclassifiedItems += 1;
@@ -1447,6 +1477,8 @@ export function postprocessDraftFromEvidence(draft, evidence) {
     applied: true,
     removed_duplicate_source_refs: deduped.removedDuplicateRefs,
     dropped_empty_source_items: deduped.droppedItems,
+    removed_release_noise_refs: noiseFiltered.removedNoiseRefs,
+    dropped_release_noise_items: noiseFiltered.droppedNoiseItems,
     reclassified_items: reclassifiedItems,
     expanded_known_items: expanded.expandedKnownItems,
     final_item_count: items.length,
@@ -1455,6 +1487,8 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   if (
     postprocess.removed_duplicate_source_refs > 0 ||
     postprocess.dropped_empty_source_items > 0 ||
+    postprocess.removed_release_noise_refs > 0 ||
+    postprocess.dropped_release_noise_items > 0 ||
     postprocess.reclassified_items > 0 ||
     postprocess.expanded_known_items > 0
   ) {
@@ -1653,6 +1687,10 @@ function cleanError(value) {
   return String(value || "")
     .replace(/Bearer\s+\S+/gi, "Bearer ***")
     .replace(/sk-[A-Za-z0-9_-]+/g, "sk-***")
+    .replace(/\bgithub_pat_[A-Za-z0-9_]+\b/g, "github_pat_***")
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]+\b/g, "gh_***")
+    .replace(/\bnpm_[A-Za-z0-9_]+\b/g, "npm_***")
+    .replace(/(_authToken\s*[=:]\s*)\S+/gi, "$1***")
     .replace(/https?:\/\/[^\s"'<>]+/gi, "https://***")
     .replace(/\b\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?\b/g, "***")
     .replace(/\s+/g, " ")
@@ -1716,6 +1754,57 @@ export async function reportFailure({ evidence, attempts, finalError, phase = "r
     throw new Error(`Failure-report endpoint returned HTTP ${response.status}`);
   }
   return response.json();
+}
+
+async function reportFailureBestEffort(args) {
+  try {
+    return await reportFailure(args);
+  } catch (error) {
+    const reason = cleanError(error?.message || error);
+    warn(`Failed to report the exhausted release workflow error: ${reason}`);
+    return { skipped: true, reason };
+  }
+}
+
+export function validationFailureAttempts(draft) {
+  return (Array.isArray(draft?.repair_attempts) ? draft.repair_attempts : [])
+    .filter((attempt) => attempt?.stage === "repair" && !attempt?.ok)
+    .slice(-MAX_DRAFT_REPAIR_ATTEMPTS)
+    .map((attempt) => {
+      const kinds = [
+        ...new Set(
+          (Array.isArray(attempt?.issues) ? attempt.issues : [])
+            .map((issue) => String(issue?.kind || "").trim())
+            .filter(Boolean),
+        ),
+      ];
+      return {
+        error_code: "RELEASE_NOTES_VALIDATION",
+        message: JSON.stringify({
+          repair_attempt: attempt.repair_attempt,
+          issue_kinds: kinds,
+          issues: attempt.issues || [],
+        }),
+        retryable: false,
+      };
+    });
+}
+
+export async function reportValidationFailureIfExhausted(
+  { draft, evidence },
+  { fetchImpl = fetch } = {},
+) {
+  const attempts = validationFailureAttempts(draft);
+  if (attempts.length < MAX_DRAFT_REPAIR_ATTEMPTS) {
+    return { skipped: true, reason: "validation repair attempts not exhausted" };
+  }
+  return reportFailureBestEffort({
+    evidence,
+    attempts,
+    finalError: JSON.stringify(draft?.validation_report || draft?.coverage || {}),
+    phase: "release-notes-validation",
+    fetchImpl,
+  });
 }
 
 export async function reportExternalFailureFromEnv({ fetchImpl = fetch } = {}) {
@@ -1792,7 +1881,7 @@ export async function requestDraft(
           return payload;
         }
         if (serverAttempts.length >= 3) {
-          await reportFailure({
+          await reportFailureBestEffort({
             evidence,
             attempts: serverAttempts.map((item) => ({
               error_code: "DRAFT_VALIDATION",
@@ -1818,7 +1907,7 @@ export async function requestDraft(
       attempts.push(entry);
       if (!entry.retryable || attempt === 3) {
         if (attempts.length === 3) {
-          await reportFailure({ evidence, attempts, finalError: entry.message, fetchImpl });
+          await reportFailureBestEffort({ evidence, attempts, finalError: entry.message, fetchImpl });
         }
         fail(`Release-notes draft request failed on attempt ${attempt}: ${entry.message}`);
       }
@@ -1986,6 +2075,9 @@ export async function main() {
   console.log(`Repair attempts: ${draft.repair_attempt_count ?? ""}`);
 
   if (!draft.ok || draft.needs_review) {
+    if (draftUsed) {
+      await reportValidationFailureIfExhausted({ draft, evidence });
+    }
     fail(`Postprocessed release notes require review: ${JSON.stringify(draft.validation_report || draft.coverage || {})}`);
   }
 }

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -498,8 +498,11 @@ function buildSourceRefIndex(evidence) {
   const excludedRefs = new Set();
 
   for (const commit of evidence?.commits || []) {
-    for (const ref of refsForCommit(commit)) {
+    const commitRefs = refsForCommit(commit);
+    const groupKey = normalizeSourceRef(commit?.short_sha) || commitRefs[0] || "";
+    for (const ref of commitRefs) {
       knownRefs.add(ref);
+      if (groupKey) refToGroup.set(ref, groupKey);
       if (isReleaseNoiseSubject(commit?.subject)) excludedRefs.add(ref);
     }
   }
@@ -894,7 +897,15 @@ function dedupeSourceRefsByBestCategory(items, index) {
       const groupKey = groupKeyForRef(ref, index.refToGroup);
       const owner = ownerByGroup.get(groupKey);
       if (!owner || owner === item) {
-        if (!refs.includes(ref)) refs.push(ref);
+        const canonicalRef =
+          /^[a-f0-9]{40}$/i.test(ref) && /^[a-f0-9]{7,12}$/i.test(groupKey)
+            ? groupKey
+            : ref;
+        if (!refs.includes(canonicalRef)) {
+          refs.push(canonicalRef);
+        } else {
+          removedDuplicateRefs += 1;
+        }
       } else {
         removedDuplicateRefs += 1;
       }

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -40,7 +40,21 @@ const REPOSITORY = "MemTensor/MemOS-Cloud-OpenClaw-Plugin";
 const CURRENT_TAG_PREFIX = "v";
 const RELEASE_NOTES_MARKER = "doc-agent-release-notes-json";
 const RELEASE_CATEGORY_ORDER = ["Added", "Improved", "Fixed"];
-const MAX_DRAFT_REPAIR_ATTEMPTS = 2;
+const MAX_DRAFT_REPAIR_ATTEMPTS = 3;
+export const RELEASE_NOTE_QUALITY_REQUEST = {
+  schema: "memos.plugin.release_notes.quality_request.v1",
+  candidate_count: 3,
+  selection_policy: [
+    "Generate multiple candidate release-note drafts when the draft service supports candidate self-evaluation.",
+    "Score candidates against evidence coverage, source_ref validity, bilingual language separation, product-facing clarity, and docs-preview readability.",
+    "Return only the best candidate in release_items/release_notes_markdown; include candidate scoring metadata only in debug fields when available.",
+  ],
+  repair_policy: {
+    max_repair_attempts: MAX_DRAFT_REPAIR_ATTEMPTS,
+    use_validation_report: true,
+    fail_closed_after_exhaustion: true,
+  },
+};
 const RELEASE_TO_DOC_CATEGORY = {
   Added: "New Features",
   Improved: "Improvements",
@@ -287,6 +301,7 @@ export function collectEvidence({ targetVersion, currentTag, previousTag, curren
   return {
     product_id: PRODUCT_ID,
     product_title: PRODUCT_TITLE,
+    release_note_quality_request: RELEASE_NOTE_QUALITY_REQUEST,
     release_note_guidance: releaseNoteGuidanceForCommits(commits),
     repo,
     previous_tag: previousTag,
@@ -314,6 +329,7 @@ export function evidenceForInspection(evidence) {
   const guidance = evidence?.release_note_guidance || {};
   const {
     release_note_guidance: _releaseNoteGuidance,
+    release_note_quality_request: _releaseNoteQualityRequest,
     important_diff: _importantDiff,
     ...publicEvidence
   } = evidence || {};
@@ -327,6 +343,7 @@ export function evidenceForInspection(evidence) {
     redactions: {
       important_diff: "omitted from public workflow artifacts; sent only to the configured draft service",
       release_note_prompt_guidance: "omitted from public workflow artifacts",
+      release_note_quality_request: "omitted from public workflow artifacts; sent only to the configured draft service",
     },
   };
 }
@@ -1037,6 +1054,7 @@ function repairContextFromValidation({ draft, validationReport, repairAttempt, m
       "Treat text_cn as the canonical wording first; text_en must be a faithful translation of text_cn, not an independently invented summary.",
       "Keep existing valid category and source_refs unchanged. Do not add source_refs that are not present in the evidence.",
       "For missing_required_source issues, add a concise product-facing item or attach the listed refs to a semantically matching existing item, using only the listed evidence.",
+      "When several valid repairs are possible, privately compare alternatives and return the candidate with the best evidence coverage, bilingual quality, and docs-preview readability.",
       "Return the same release_items schema with category, text_cn, text_en, and source_refs.",
     ],
   };

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -1369,7 +1369,11 @@ export function validateManualNotes(notes) {
   if (payload?.coverage?.needs_review !== false) {
     fail("Manual release notes evidence coverage must explicitly set needs_review=false.");
   }
-  for (const item of payload.items) {
+  const normalizedItems = payload.items.map(normalizeReleaseItem);
+  if (normalizedItems.some((item) => !item)) {
+    fail("Every manual release-note item must include category, text_cn, text_en, and valid source_refs.");
+  }
+  for (const item of normalizedItems) {
     if (!item?.text_cn || !item?.text_en || !Array.isArray(item?.source_refs) || item.source_refs.length === 0) {
       fail("Every manual release-note item must include text_cn, text_en, and source_refs.");
     }

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -89,6 +89,7 @@ test("finds previous tags using SemVer precedence for prerelease numbers", () =>
     runGit(dir, ["commit", "-m", "seed"]);
     runGit(dir, ["tag", "v1.0.0"]);
     runGit(dir, ["tag", "v1.0.1+build.1"]);
+    runGit(dir, ["tag", "v1.0.1-beta.1"]);
     for (let i = 1; i <= 19; i++) {
       runGit(dir, ["tag", `v1.0.0-beta.${i}`]);
     }
@@ -97,6 +98,8 @@ test("finds previous tags using SemVer precedence for prerelease numbers", () =>
     assert.equal(findPreviousTag("1.0.0-beta.10", "v1.0.0-beta.10"), "v1.0.0-beta.9");
     assert.equal(findPreviousTag("1.0.0-beta.11", "v1.0.0-beta.11"), "v1.0.0-beta.10");
     assert.equal(findPreviousTag("1.0.0-beta.20", "v1.0.0-beta.20"), "v1.0.0-beta.19");
+    // Prereleases are preview-only in the Docs pipeline, so a stable release
+    // must include the full delta from the previous stable tag.
     assert.equal(findPreviousTag("1.0.1+build.2", "v1.0.1+build.2"), "v1.0.0");
   } finally {
     process.chdir(previousCwd);

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -9,10 +9,13 @@ import {
   cleanVersion,
   categoryHintsForCommits,
   compareSemver,
+  docsPreviewFromDraft,
   draftForInspection,
   evidenceForInspection,
   ensureSourceHint,
   findPreviousTag,
+  main,
+  markdownFromDocsPreview,
   postprocessDraftFromEvidence,
   RELEASE_NOTE_GUIDANCE,
   reportExternalFailureFromEnv,
@@ -233,6 +236,216 @@ test("postprocesses duplicate source refs into the best evidence category", () =
   assert.match(processed.release_notes_markdown, /doc-agent-release-notes-json/);
 });
 
+test("rewrites known system prompt handling evidence into docs-ready cloud plugin bullets", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Added",
+          text_cn: "**增强系统提示检测**：提升了 OpenClaw 系统提示的检测和处理能力。",
+          text_en: "**Enhanced System Prompt Detection**: Improved detection and handling of OpenClaw system prompts.",
+          source_refs: ["d053b0a"],
+        },
+      ],
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      important_diff: {
+        "openclaw-cloud-plugin/**":
+          "isForcedSystemMessage scheduled task scheduled reminder background command system prompt false positive single-line flattened",
+      },
+      commits: [
+        {
+          sha: "d053b0a000000000000000000000000000000000",
+          short_sha: "d053b0a",
+          subject: "feat: enhance OpenClaw system prompt detection and handling",
+        },
+      ],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Added",
+            source_refs: ["d053b0a"],
+            subject: "feat: enhance OpenClaw system prompt detection and handling",
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.equal(processed.release_items.length, 2);
+  assert.deepEqual(
+    processed.release_items.map((item) => item.category),
+    ["Improved", "Improved"],
+  );
+  assert.match(processed.release_items[0].text_cn, /系统事件过滤增强/);
+  assert.match(processed.release_items[1].text_cn, /系统提示识别优化/);
+  assert.equal(processed.coverage.missing_required_count, 0);
+  assert.deepEqual(processed.docs_categories.cn.Improvements, [
+    "**系统事件过滤增强**：自动跳过定时任务、计划提醒和后台命令结果，减少记忆污染。",
+    "**系统提示识别优化**：兼容单行压缩内容并降低普通消息误判概率。",
+  ]);
+});
+
+test("uses evidence subjects ahead of off-topic draft text for known cloud plugin topics", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Added",
+          text_cn: "**增强系统提示检测**：提升了 OpenClaw 系统提示的检测和处理能力。",
+          text_en: "**Enhanced System Prompt Detection**: Improved detection and handling of OpenClaw system prompts.",
+          source_refs: ["5152641"],
+        },
+      ],
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits: [
+        {
+          sha: "5152641c4b564857f23f46b1ea81f9319ef3fd4a",
+          short_sha: "5152641",
+          subject: "feat: add config UI update check",
+        },
+      ],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Added",
+            source_refs: ["5152641"],
+            subject: "feat: add config UI update check",
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.equal(processed.release_items.length, 1);
+  assert.match(processed.release_items[0].text_cn, /配置页新增更新检查/);
+  assert.match(processed.release_items[0].text_en, /Update checks in settings/);
+  assert.deepEqual(processed.release_items[0].source_refs, ["5152641"]);
+  assert.deepEqual(processed.docs_categories.cn.Improvements, [
+    "**配置页新增更新检查**：可查看版本状态，并复制对应宿主的更新重启命令。",
+  ]);
+});
+
+test("splits collapsed multi-ref historical drafts into docs-ready cloud plugin topics", () => {
+  const commits = [
+    {
+      sha: "306841f000000000000000000000000000000000",
+      short_sha: "306841f",
+      subject:
+        "feat: update recall hook registration to use before_prompt_build for newer OpenClaw hosts and add tests for version compatibility",
+    },
+    {
+      sha: "bf25eb70000000000000000000000000000000000",
+      short_sha: "bf25eb7",
+      subject:
+        "feat: implement system event detection in recall and agent end hooks to skip processing for heartbeat and command events",
+    },
+    {
+      sha: "eb2bddc000000000000000000000000000000000",
+      short_sha: "eb2bddc",
+      subject: "feat: add function to strip leading system notes from text input",
+    },
+    {
+      sha: "f7c1edb000000000000000000000000000000000",
+      short_sha: "f7c1edb",
+      subject: "feat: refactor system event detection logic into dedicated functions for clarity and reuse",
+    },
+    {
+      sha: "9c773370000000000000000000000000000000000",
+      short_sha: "9c77337",
+      subject: "feat: enhance memory section handling by adding tool memory support and simplifying filtering logic",
+    },
+    {
+      sha: "ed52b9c000000000000000000000000000000000",
+      short_sha: "ed52b9c",
+      subject:
+        "feat: extend system command detection to include 'clear' command and add internal prompt patterns for session management",
+    },
+  ];
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Added",
+          text_cn: "**Hook 与记忆能力增强**：优化云插件 hook、系统事件、工具记忆和提示处理。",
+          text_en: "**Hook and memory improvements**: Improves cloud plugin hooks, system events, tool memory, and prompt handling.",
+          source_refs: ["306841f", "bf25eb7", "eb2bddc", "f7c1edb", "9c77337", "ed52b9c"],
+        },
+      ],
+      coverage: { required_count: 6, covered_required_count: 6, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits,
+      release_note_guidance: {
+        source_ref_category_hints: commits.map((commit) => ({
+          category: commit.short_sha === "f7c1edb" || commit.short_sha === "ed52b9c" ? "Improved" : "Added",
+          source_refs: [commit.short_sha],
+          subject: commit.subject,
+        })),
+      },
+    },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.equal(processed.coverage.missing_required_count, 0);
+  assert.equal(processed.release_items.length, 7);
+  assert.deepEqual(
+    processed.release_items.map((item) => item.source_refs[0]),
+    ["306841f", "bf25eb7", "eb2bddc", "f7c1edb", "9c77337", "9c77337", "ed52b9c"],
+  );
+  assert.match(processed.release_notes_markdown, /Recall Hook 兼容新版 OpenClaw/);
+  assert.match(processed.release_notes_markdown, /系统事件自动跳过/);
+  assert.match(processed.release_notes_markdown, /System Note 前缀自动剥离/);
+  assert.match(processed.release_notes_markdown, /系统事件检测重构/);
+  assert.match(processed.release_notes_markdown, /工具记忆全链路支持/);
+  assert.match(processed.release_notes_markdown, /记忆过滤逻辑精简/);
+  assert.match(processed.release_notes_markdown, /内部提示识别增强/);
+});
+
+test("generates bilingual MemOS-Docs preview from postprocessed release items", () => {
+  const draft = {
+    docs_categories: {
+      cn: {
+        Improvements: [
+          "**系统事件过滤增强**：自动跳过定时任务、计划提醒和后台命令结果，减少记忆污染。",
+        ],
+      },
+      en: {
+        Improvements: [
+          "**System-event filtering**: Skips scheduled tasks, reminders, and background command results to keep memory cleaner.",
+        ],
+      },
+    },
+  };
+  const preview = docsPreviewFromDraft(draft, {
+    targetVersion: "0.1.20",
+    publishedAt: "2026-07-23T08:00:00Z",
+  });
+  const markdown = markdownFromDocsPreview(preview);
+
+  assert.equal(preview.version, "v0.1.20");
+  assert.equal(preview.date, "2026-07-23");
+  assert.equal(preview.docs_files.cn, "content/cn/plugin-changelog.yml");
+  assert.equal(preview.entries.cn.products.plugin.Improvements[0].type, "OpenClaw 云插件");
+  assert.equal(preview.entries.en.products.plugin.Improvements[0].type, "OpenClaw Cloud Plugin");
+  assert.match(markdown, /中文预览/);
+  assert.match(markdown, /System-event filtering/);
+});
+
 test("postprocess fails closed when English and Chinese text cross languages", () => {
   const processed = postprocessDraftFromEvidence(
     {
@@ -414,6 +627,42 @@ test("manual notes require bilingual evidence refs and passed coverage", () => {
   );
 });
 
+test("manual release notes also produce docs preview outputs", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "cloud-plugin-manual-preview-"));
+  const previous = { ...process.env };
+  try {
+    const outputPath = join(directory, "github-output.txt");
+    const notesPath = join(directory, "release-notes.md");
+    Object.assign(process.env, {
+      RELEASE_VERSION: "0.1.20",
+      RELEASE_NOTES_FILE: notesPath,
+      MANUAL_RELEASE_NOTES: `## Changelog
+
+### Improved
+- **系统事件过滤增强**：自动跳过定时任务、计划提醒和后台命令结果，减少记忆污染。
+
+<!-- doc-agent-release-notes-json
+{"items":[{"category":"Improved","text_cn":"**系统事件过滤增强**：自动跳过定时任务、计划提醒和后台命令结果，减少记忆污染。","text_en":"**System-event filtering**: Skips scheduled tasks, reminders, and background command results to keep memory cleaner.","source_refs":["d053b0a"]}],"coverage":{"needs_review":false,"required_count":1,"covered_required_count":1,"missing_required_count":0}}
+-->`,
+      GITHUB_OUTPUT: outputPath,
+    });
+
+    await main();
+
+    const output = readFileSync(outputPath, "utf8");
+    const match = output.match(/docs_preview_markdown_file<<__DOC_AGENT_EOF__\n([\s\S]*?)\n__DOC_AGENT_EOF__/);
+    assert.ok(match, "docs preview markdown output should be written");
+    const preview = readFileSync(match[1], "utf8");
+    assert.match(preview, /MemOS-Docs Plugin Changelog Preview/);
+    assert.match(preview, /OpenClaw 云插件/);
+    assert.match(preview, /System-event filtering/);
+    assert.match(readFileSync(notesPath, "utf8"), /doc-agent: source-id=openclaw-cloud-plugin/);
+  } finally {
+    process.env = previous;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("reports three external-operation attempt logs with a sanitized phase", async () => {
   const directory = mkdtempSync(join(tmpdir(), "cloud-plugin-release-failure-"));
   const previous = { ...process.env };
@@ -465,6 +714,79 @@ test("retries transient draft failures and passes prior error context", async ()
   } finally {
     process.env = previous;
   }
+});
+
+test("keeps structured needs-review drafts for local validation instead of failing immediately", async () => {
+  const previous = { ...process.env };
+  try {
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL = "https://example.invalid/draft";
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    const result = await requestDraft(evidence, {
+      fetchImpl: async () =>
+        response(200, {
+          ok: false,
+          needs_review: true,
+          warnings: ["English output contains CJK text"],
+          release_items: [
+            {
+              category: "Improved",
+              text_cn: "**系统事件过滤增强**：自动跳过后台命令结果。",
+              text_en: "**System-event Filtering**：自动跳过后台命令结果。",
+              source_refs: ["abc1234"],
+            },
+          ],
+          coverage: { needs_review: true, required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+        }),
+      sleep: async () => {},
+    });
+    assert.equal(result.needs_review, true);
+    assert.equal(result.release_items.length, 1);
+  } finally {
+    process.env = previous;
+  }
+});
+
+test("repairs mixed-language structured drafts by sending validation context back to the drafter", async () => {
+  const requests = [];
+  const result = await requestValidatedDraft(evidence, {
+    requestImpl: async (requestEvidence) => {
+      requests.push(requestEvidence);
+      if (requests.length === 1) {
+        return {
+          ok: false,
+          needs_review: true,
+          release_items: [
+            {
+              category: "Improved",
+              text_cn: "**系统事件过滤增强**：自动跳过后台命令结果。",
+              text_en: "**System-event Filtering**：自动跳过后台命令结果。",
+              source_refs: ["abc1234"],
+            },
+          ],
+          coverage: { needs_review: true, required_count: 0, covered_required_count: 0, missing_required_count: 0 },
+        };
+      }
+      assert.equal(requestEvidence.release_notes_repair_context.validation_report.language_issue_count, 1);
+      return {
+        ok: true,
+        needs_review: false,
+        release_items: [
+          {
+            category: "Improved",
+            text_cn: "**系统事件过滤增强**：自动跳过后台命令结果。",
+            text_en: "**System-event Filtering**: Skips background command results automatically.",
+            source_refs: ["abc1234"],
+          },
+        ],
+        coverage: { needs_review: false, required_count: 0, covered_required_count: 0, missing_required_count: 0 },
+      };
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.needs_review, false);
+  assert.equal(result.validation_attempt_count, 2);
+  assert.equal(result.repair_attempt_count, 1);
+  assert.match(result.release_notes_markdown, /Skips scheduled tasks, reminders, and background command results/);
 });
 
 test("reports once after three transient failures", async () => {

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -898,6 +898,20 @@ test("manual notes require bilingual evidence refs and passed coverage", () => {
 -->`;
   assert.equal(validateManualNotes(valid), valid);
   assert.match(ensureSourceHint(valid), /source-id=openclaw-cloud-plugin/);
+  assert.throws(
+    () =>
+      ensureSourceHint(
+        `${valid}\n<!-- doc-agent: source-id=test-openclaw-cloud-plugin -->`,
+      ),
+    /exactly one Doc Agent source id openclaw-cloud-plugin/,
+  );
+  assert.throws(
+    () =>
+      ensureSourceHint(
+        `${valid}\n<!-- doc-agent: source-id=openclaw-local-plugin -->`,
+      ),
+    /exactly one Doc Agent source id openclaw-cloud-plugin/,
+  );
   assert.throws(() => validateManualNotes("## Changelog\n- unsupported"), /evidence block/);
   assert.throws(
     () =>

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -18,6 +18,7 @@ import {
   markdownFromDocsPreview,
   postprocessDraftFromEvidence,
   RELEASE_NOTE_GUIDANCE,
+  RELEASE_NOTE_QUALITY_REQUEST,
   reportExternalFailureFromEnv,
   requestDraft,
   requestValidatedDraft,
@@ -114,6 +115,13 @@ test("documents cloud release-note guidance", () => {
   assert.ok(
     RELEASE_NOTE_GUIDANCE.translation_policy.some((item) =>
       item.includes("Treat text_cn as the canonical release-note wording first"),
+    ),
+  );
+  assert.equal(RELEASE_NOTE_QUALITY_REQUEST.candidate_count, 3);
+  assert.equal(RELEASE_NOTE_QUALITY_REQUEST.repair_policy.max_repair_attempts, 3);
+  assert.ok(
+    RELEASE_NOTE_QUALITY_REQUEST.selection_policy.some((item) =>
+      item.includes("Score candidates against evidence coverage"),
     ),
   );
 });
@@ -601,6 +609,55 @@ test("stops release-note repair after two validation repair attempts", async () 
   assert.equal(requests.length, 3);
 });
 
+test("defaults to three validation repair attempts before failing closed", async () => {
+  const repairEvidence = {
+    commits: [
+      {
+        sha: "abc12340000000000000000000000000000000",
+        short_sha: "abc1234",
+        subject: "feat: add plugin health dashboard (#3001)",
+      },
+    ],
+    release_note_guidance: {
+      source_ref_category_hints: [
+        {
+          category: "Added",
+          source_refs: ["abc1234", "#3001"],
+          subject: "feat: add plugin health dashboard (#3001)",
+        },
+      ],
+    },
+  };
+  const crossedDraft = {
+    ok: true,
+    needs_review: false,
+    release_items: [
+      {
+        category: "Added",
+        text_cn: "Plugin health dashboard",
+        text_en: "插件健康看板",
+        source_refs: ["abc1234", "#3001"],
+      },
+    ],
+    coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+    warnings: [],
+  };
+  const requests = [];
+  const result = await requestValidatedDraft(repairEvidence, {
+    requestImpl: async (payload) => {
+      requests.push(payload);
+      return crossedDraft;
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.needs_review, true);
+  assert.equal(result.repair_attempt_count, 3);
+  assert.equal(result.validation_attempt_count, 4);
+  assert.equal(requests.length, 4);
+  assert.equal(requests[3].release_notes_repair_context.max_repair_attempts, 3);
+});
+
 test("manual notes require bilingual evidence refs and passed coverage", () => {
   const valid = `## Changelog
 
@@ -711,6 +768,38 @@ test("retries transient draft failures and passes prior error context", async ()
     assert.equal(requests.length, 3);
     assert.equal(requests[1].workflow_retry_context.previous_errors.length, 1);
     assert.equal(requests[2].workflow_retry_context.previous_errors.length, 2);
+  } finally {
+    process.env = previous;
+  }
+});
+
+test("passes release-note quality request to the draft service", async () => {
+  const previous = { ...process.env };
+  try {
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL = "https://example.invalid/draft";
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    let requestBody;
+    const result = await requestDraft(
+      {
+        ...evidence,
+        release_note_quality_request: RELEASE_NOTE_QUALITY_REQUEST,
+      },
+      {
+        fetchImpl: async (_url, options) => {
+          requestBody = JSON.parse(options.body);
+          return response(200, {
+            ok: true,
+            needs_review: false,
+            release_notes_markdown: "## Changelog\n\n### Improved\n- ok",
+          });
+        },
+        sleep: async () => {},
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(requestBody.release_note_quality_request.candidate_count, 3);
+    assert.equal(requestBody.release_note_quality_request.repair_policy.max_repair_attempts, 3);
+    assert.match(requestBody.release_note_quality_request.selection_policy.join("\n"), /docs-preview readability/);
   } finally {
     process.env = previous;
   }

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -25,9 +25,11 @@ import {
   RELEASE_NOTE_LIMITS,
   RELEASE_NOTE_QUALITY_REQUEST,
   reportExternalFailureFromEnv,
+  reportValidationFailureIfExhausted,
   requestDraft,
   requestValidatedDraft,
   resolveCurrentRef,
+  validationFailureAttempts,
   validateManualNotes,
   versionFromTag,
 } from "./draft-cloud-plugin-release-notes.mjs";
@@ -358,6 +360,108 @@ test("uses evidence subjects ahead of off-topic draft text for known cloud plugi
   ]);
 });
 
+test("keeps historical product topics while removing release-automation and version noise refs", () => {
+  const commits = [
+    {
+      sha: "70fb1840fdd73a7a04e5f946148cc94b916dad77",
+      short_sha: "70fb184",
+      subject: "feat: update MEMOS_SOURCE to append platform-specific suffixes and add corresponding tests",
+    },
+    {
+      sha: "5152641c4b564857f23f46b1ea81f9319ef3fd4a",
+      short_sha: "5152641",
+      subject: "feat: add config UI update check",
+    },
+    {
+      sha: "d053b0a2764daa923bbeeeb699c949ef0112a437",
+      short_sha: "d053b0a",
+      subject: "feat: enhance OpenClaw system prompt detection and handling",
+    },
+    {
+      sha: "0dde13c000000000000000000000000000000000",
+      short_sha: "0dde13c",
+      subject: "ci: harden cloud plugin release previews",
+    },
+    {
+      sha: "0c2cd2a1a51f6cbfc744a51462ba54ad8ed3f22a",
+      short_sha: "0c2cd2a",
+      subject: "0.1.19",
+    },
+  ];
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Added",
+          text_cn: "**云插件更新**：汇总跨平台来源、配置页更新检查和系统提示处理。",
+          text_en:
+            "**Cloud plugin updates**: Summarizes platform-aware sources, settings update checks, and system prompt handling.",
+          source_refs: commits.map((commit) => commit.short_sha),
+        },
+      ],
+      coverage: { needs_review: false },
+      warnings: [],
+    },
+    {
+      commits,
+      release_note_guidance: {
+        source_ref_category_hints: categoryHintsForCommits(commits),
+      },
+    },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.equal(processed.coverage.missing_required_count, 0);
+  assert.equal(processed.postprocess.removed_release_noise_refs, 2);
+  assert.ok(
+    processed.release_items.every(
+      (item) => !item.source_refs.includes("0dde13c") && !item.source_refs.includes("0c2cd2a"),
+    ),
+  );
+  assert.match(processed.release_notes_markdown, /跨平台记忆来源识别/);
+  assert.match(processed.release_notes_markdown, /配置页新增更新检查/);
+  assert.match(processed.release_notes_markdown, /系统事件过滤增强/);
+  assert.match(processed.release_notes_markdown, /系统提示识别优化/);
+  assert.doesNotMatch(processed.release_notes_markdown, /发布预览|release previews|0dde13c|0c2cd2a/);
+});
+
+test("fails closed when a draft contains only release-automation evidence", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Improved",
+          text_cn: "**发布流程优化**：增强发布预览与重试。",
+          text_en: "**Release workflow improvements**: Improves release previews and retries.",
+          source_refs: ["0dde13c"],
+        },
+      ],
+      coverage: { needs_review: false },
+      warnings: [],
+    },
+    {
+      commits: [
+        {
+          sha: "0dde13c000000000000000000000000000000000",
+          short_sha: "0dde13c",
+          subject: "ci: harden cloud plugin release previews",
+        },
+      ],
+      release_note_guidance: { source_ref_category_hints: [] },
+    },
+  );
+
+  assert.equal(processed.ok, false);
+  assert.equal(processed.needs_review, true);
+  assert.deepEqual(processed.release_items, []);
+  assert.equal(processed.postprocess.dropped_release_noise_items, 1);
+  assert.ok(processed.validation_report.issues.some((issue) => issue.kind === "empty_release_items"));
+});
+
 test("splits collapsed multi-ref historical drafts into docs-ready cloud plugin topics", () => {
   const commits = [
     {
@@ -514,7 +618,7 @@ test("postprocess fails closed when cloud plugin docs output is too noisy", () =
     return {
       sha: `${short}${"0".repeat(33)}`,
       short_sha: short,
-      subject: `feat: improve cloud plugin release note quality ${index + 1} (#${3001 + index})`,
+      subject: `feat: improve cloud memory recall quality ${index + 1} (#${3001 + index})`,
     };
   });
   const noisyItems = Array.from({ length: 13 }, (_item, index) => ({
@@ -570,7 +674,7 @@ test("postprocess fails closed when cloud plugin docs bullets are too long", () 
         {
           sha: "abc12340000000000000000000000000000000",
           short_sha: "abc1234",
-          subject: "feat: improve cloud plugin release note quality (#3001)",
+          subject: "feat: improve cloud memory recall quality (#3001)",
         },
       ],
       release_note_guidance: {
@@ -578,7 +682,7 @@ test("postprocess fails closed when cloud plugin docs bullets are too long", () 
           {
             category: "Improved",
             source_refs: ["abc1234", "#3001"],
-            subject: "feat: improve cloud plugin release note quality (#3001)",
+            subject: "feat: improve cloud memory recall quality (#3001)",
           },
         ],
       },
@@ -753,6 +857,74 @@ test("defaults to three validation repair attempts before failing closed", async
   assert.equal(result.validation_attempt_count, 4);
   assert.equal(requests.length, 4);
   assert.equal(requests[3].release_notes_repair_context.max_repair_attempts, 3);
+});
+
+test("reports the three semantic repair failures after validation exhaustion", async () => {
+  const previous = { ...process.env };
+  try {
+    process.env.DOC_AGENT_RELEASE_FAILURE_URL = "https://example.invalid/failure";
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    const draft = {
+      ok: false,
+      needs_review: true,
+      validation_report: {
+        ok: false,
+        needs_review: true,
+        issues: [{ kind: "language", field: "text_en" }],
+      },
+      repair_attempts: [
+        { stage: "draft", repair_attempt: 0, ok: false, issues: [{ kind: "language" }] },
+        { stage: "repair", repair_attempt: 1, ok: false, issues: [{ kind: "language" }] },
+        { stage: "repair", repair_attempt: 2, ok: false, issues: [{ kind: "language" }] },
+        { stage: "repair", repair_attempt: 3, ok: false, issues: [{ kind: "language" }] },
+      ],
+    };
+    assert.deepEqual(
+      validationFailureAttempts(draft).map((attempt) => JSON.parse(attempt.message).repair_attempt),
+      [1, 2, 3],
+    );
+
+    let report;
+    const result = await reportValidationFailureIfExhausted(
+      { draft, evidence },
+      {
+        fetchImpl: async (_url, options) => {
+          report = JSON.parse(options.body);
+          return response(200, { ok: true, sent: true });
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(report.phase, "release-notes-validation");
+    assert.deepEqual(report.attempts.map((attempt) => attempt.attempt), [1, 2, 3]);
+    assert.ok(report.attempts.every((attempt) => attempt.error_code === "RELEASE_NOTES_VALIDATION"));
+    assert.match(report.final_error, /language/);
+  } finally {
+    process.env = previous;
+  }
+});
+
+test("does not report semantic validation before all three repairs are exhausted", async () => {
+  let called = false;
+  const result = await reportValidationFailureIfExhausted(
+    {
+      evidence,
+      draft: {
+        repair_attempts: [
+          { stage: "repair", repair_attempt: 1, ok: false, issues: [{ kind: "language" }] },
+          { stage: "repair", repair_attempt: 2, ok: false, issues: [{ kind: "language" }] },
+        ],
+      },
+    },
+    {
+      fetchImpl: async () => {
+        called = true;
+        return response(200, { ok: true });
+      },
+    },
+  );
+  assert.equal(result.skipped, true);
+  assert.equal(called, false);
 });
 
 test("fault injection covers every required cloud-plugin degradation sample", () => {
@@ -960,17 +1132,19 @@ test("manual release notes also produce docs preview outputs", async () => {
   try {
     const outputPath = join(directory, "github-output.txt");
     const notesPath = join(directory, "release-notes.md");
-    const sourceRef = runGit(process.cwd(), ["rev-parse", "--short", "HEAD"]);
+    const sourceRef = runGit(process.cwd(), ["rev-parse", "--short", "d053b0a"]);
     Object.assign(process.env, {
-      RELEASE_VERSION: "0.1.20",
+      RELEASE_VERSION: "0.1.19",
+      RELEASE_TAG: "v0.1.19",
+      RELEASE_EVIDENCE_REF: "v0.1.19",
       RELEASE_NOTES_FILE: notesPath,
       MANUAL_RELEASE_NOTES: `## Changelog
 
 ### Improved
-- **发布预览护栏**：增强云插件发布前的检查信息。
+- **系统提示识别优化**：兼容单行压缩内容并降低普通消息误判概率。
 
 <!-- doc-agent-release-notes-json
-{"items":[{"category":"Improved","text_cn":"**发布预览护栏**：增强云插件发布前的检查信息。","text_en":"**Release preview guardrails**: Improves pre-publish inspection details for the cloud plugin.","source_refs":["${sourceRef}"]}],"coverage":{"needs_review":false,"required_count":0,"covered_required_count":0,"missing_required_count":0}}
+{"items":[{"category":"Improved","text_cn":"**系统提示识别优化**：兼容单行压缩内容并降低普通消息误判概率。","text_en":"**System prompt detection**: Supports flattened single-line prompts and reduces false positives on regular messages.","source_refs":["${sourceRef}"]}],"coverage":{"needs_review":false,"required_count":1,"covered_required_count":1,"missing_required_count":0}}
 -->`,
       GITHUB_OUTPUT: outputPath,
     });
@@ -983,7 +1157,7 @@ test("manual release notes also produce docs preview outputs", async () => {
     const preview = readFileSync(match[1], "utf8");
     assert.match(preview, /MemOS-Docs Plugin Changelog Preview/);
     assert.match(preview, /OpenClaw 云插件/);
-    assert.match(preview, /Release preview guardrails/);
+    assert.match(preview, /System prompt detection/);
     assert.match(readFileSync(notesPath, "utf8"), /doc-agent: source-id=openclaw-cloud-plugin/);
     const qualityMatch = output.match(
       /quality_report_file<<__DOC_AGENT_EOF__\n([\s\S]*?)\n__DOC_AGENT_EOF__/,
@@ -1214,6 +1388,33 @@ test("reports once after three transient failures", async () => {
   }
 });
 
+test("keeps the original draft failure when the failure-report endpoint is unavailable", async () => {
+  const previous = { ...process.env };
+  try {
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL = "https://example.invalid/draft";
+    process.env.DOC_AGENT_RELEASE_FAILURE_URL = "https://example.invalid/failure";
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    let draftCalls = 0;
+    let reportCalls = 0;
+    const fetchImpl = async (url) => {
+      if (url.includes("/failure")) {
+        reportCalls += 1;
+        return response(503, { detail: "failure sink unavailable" });
+      }
+      draftCalls += 1;
+      return response(503, { detail: "draft service busy" });
+    };
+    await assert.rejects(
+      requestDraft(evidence, { fetchImpl, sleep: async () => {} }),
+      /Release-notes draft request failed on attempt 3: HTTP 503/,
+    );
+    assert.equal(draftCalls, 3);
+    assert.equal(reportCalls, 1);
+  } finally {
+    process.env = previous;
+  }
+});
+
 test("requires configured draft URL instead of using a public fallback", async () => {
   const previous = { ...process.env };
   try {
@@ -1239,15 +1440,23 @@ test("sanitizes configured URLs and IPs before failure reporting", async () => {
       calls.push({ url, body: JSON.parse(options.body) });
       if (url.includes("/failure")) return response(200, { ok: true, sent: true });
       throw Object.assign(
-        new Error("connect ECONNREFUSED https://example.invalid/redacted-path 127.0.0.1:4318 with Bearer test-token"),
+        new Error(
+          "connect ECONNREFUSED https://example.invalid/redacted-path 127.0.0.1:4318 " +
+            "with Bearer test-token github_pat_privatevalue ghp_privatevalue npm_privatevalue " +
+            "//registry.npmjs.org/:_authToken=privatevalue",
+        ),
         { retryable: true },
       );
     };
     await assert.rejects(requestDraft(evidence, { fetchImpl, sleep: async () => {} }), /attempt 3/);
     const report = calls.find((call) => call.url.includes("/failure"))?.body;
     assert.ok(report);
-    assert.doesNotMatch(JSON.stringify(report), /example\.invalid|redacted-path|127\.0\.0\.1|test-token/);
+    assert.doesNotMatch(
+      JSON.stringify(report),
+      /example\.invalid|redacted-path|127\.0\.0\.1|test-token|privatevalue/,
+    );
     assert.match(JSON.stringify(report), /https:\/\/\*\*\*/);
+    assert.match(JSON.stringify(report), /github_pat_\*\*\*|gh_\*\*\*|npm_\*\*\*|_authToken=\*\*\*/);
   } finally {
     process.env = previous;
   }

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -14,10 +14,15 @@ import {
   evidenceForInspection,
   ensureSourceHint,
   findPreviousTag,
+  injectReleaseFaultCase,
   main,
   markdownFromDocsPreview,
   postprocessDraftFromEvidence,
+  PRODUCT_ID,
+  qualityReportFromDraft,
+  RELEASE_FAULT_CASES,
   RELEASE_NOTE_GUIDANCE,
+  RELEASE_NOTE_LIMITS,
   RELEASE_NOTE_QUALITY_REQUEST,
   reportExternalFailureFromEnv,
   requestDraft,
@@ -143,6 +148,14 @@ test("adds source-ref category hints from cloud plugin commit subjects", () => {
     {
       short_sha: "c739e9f2",
       subject: "docs: update README",
+    },
+    {
+      short_sha: "98549947",
+      subject: "ci: cover publish confirmation guard dry runs",
+    },
+    {
+      short_sha: "c20bf70a",
+      subject: "fix: compare release tags with semver precedence",
     },
   ]);
 
@@ -495,6 +508,90 @@ test("postprocess fails closed when English and Chinese text cross languages", (
   assert.equal(processed.language_issues.length, 2);
 });
 
+test("postprocess fails closed when cloud plugin docs output is too noisy", () => {
+  const commits = Array.from({ length: 13 }, (_item, index) => {
+    const short = `abc${String(index).padStart(4, "0")}`;
+    return {
+      sha: `${short}${"0".repeat(33)}`,
+      short_sha: short,
+      subject: `feat: improve cloud plugin release note quality ${index + 1} (#${3001 + index})`,
+    };
+  });
+  const noisyItems = Array.from({ length: 13 }, (_item, index) => ({
+    category: "Improved",
+    text_cn: `**云插件优化 ${index + 1}**：优化发布说明展示效果。`,
+    text_en: `**Cloud plugin improvement ${index + 1}**: Refined release-note presentation.`,
+    source_refs: [commits[index].short_sha, `#${3001 + index}`],
+  }));
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: noisyItems,
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits,
+      release_note_guidance: {
+        source_ref_category_hints: commits.map((commit, index) => ({
+          category: "Improved",
+          source_refs: [commit.short_sha, `#${3001 + index}`],
+          subject: commit.subject,
+        })),
+      },
+    },
+  );
+
+  assert.equal(processed.ok, false);
+  assert.equal(processed.needs_review, true);
+  assert.ok(processed.readability_issues.some((issue) => issue.field === "release_items"));
+  assert.equal(processed.validation_report.readability_issue_count, 1);
+});
+
+test("postprocess fails closed when cloud plugin docs bullets are too long", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Improved",
+          text_cn: `**系统事件过滤增强**：${"用于发布说明质量验证的重复中文描述。".repeat(12)}`,
+          text_en: `**System-event filtering**: ${"This repeated English detail is intentionally too verbose for a changelog bullet. ".repeat(6)}`,
+          source_refs: ["abc1234", "#3001"],
+        },
+      ],
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits: [
+        {
+          sha: "abc12340000000000000000000000000000000",
+          short_sha: "abc1234",
+          subject: "feat: improve cloud plugin release note quality (#3001)",
+        },
+      ],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Improved",
+            source_refs: ["abc1234", "#3001"],
+            subject: "feat: improve cloud plugin release note quality (#3001)",
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(processed.ok, false);
+  assert.equal(processed.needs_review, true);
+  assert.ok(processed.readability_issues.some((issue) => issue.field === "text_cn"));
+  assert.ok(processed.readability_issues.some((issue) => issue.field === "text_en"));
+  assert.ok(processed.validation_report.repairable);
+});
+
 test("repairs postprocessed language validation issues with exact context", async () => {
   const repairEvidence = {
     commits: [
@@ -658,6 +755,138 @@ test("defaults to three validation repair attempts before failing closed", async
   assert.equal(requests[3].release_notes_repair_context.max_repair_attempts, 3);
 });
 
+test("fault injection covers every required cloud-plugin degradation sample", () => {
+  assert.deepEqual(RELEASE_FAULT_CASES, [
+    "none",
+    "mixed_language",
+    "missing_source_refs",
+    "missing_important_commit",
+    "invalid_source_ref",
+    "thirteen_items",
+    "too_long",
+    "manual_notes_missing_payload",
+  ]);
+  const draft = {
+    release_items: [
+      {
+        category: "Added",
+        text_cn: "新增云插件发布能力。",
+        text_en: "Adds cloud plugin release support.",
+        source_refs: ["abc1234"],
+      },
+    ],
+  };
+  const releaseEvidence = {
+    release_note_guidance: {
+      source_ref_category_hints: [{ source_refs: ["abc1234"] }],
+    },
+  };
+
+  assert.deepEqual(
+    injectReleaseFaultCase(draft, releaseEvidence, "missing_source_refs")
+      .release_items[0].source_refs,
+    [],
+  );
+  assert.match(
+    injectReleaseFaultCase(draft, releaseEvidence, "mixed_language", {
+      phase: "postprocess",
+    }).release_items[0].text_en,
+    /中文/,
+  );
+  assert.equal(
+    injectReleaseFaultCase(draft, releaseEvidence, "thirteen_items", {
+      phase: "postprocess",
+    }).release_items.length,
+    13,
+  );
+});
+
+test("fault injection enters one repair and then accepts a clean draft", async () => {
+  const releaseEvidence = {
+    commits: [
+      {
+        sha: "abc12340000000000000000000000000000000",
+        short_sha: "abc1234",
+        subject: "feat: improve cloud plugin release audit",
+      },
+    ],
+    release_note_guidance: {
+      source_ref_category_hints: [
+        {
+          category: "Added",
+          source_refs: ["abc1234"],
+          subject: "feat: improve cloud plugin release audit",
+        },
+      ],
+    },
+  };
+  const cleanDraft = {
+    ok: true,
+    needs_review: false,
+    release_items: [
+      {
+        category: "Added",
+        text_cn: "**发布审计**：新增云插件发布质量检查。",
+        text_en: "**Release audit**: Adds cloud plugin release quality checks.",
+        source_refs: ["abc1234"],
+      },
+    ],
+    coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+    warnings: [],
+  };
+
+  for (const faultCase of [
+    "mixed_language",
+    "missing_source_refs",
+    "missing_important_commit",
+    "invalid_source_ref",
+    "thirteen_items",
+    "too_long",
+  ]) {
+    let requests = 0;
+    const result = await requestValidatedDraft(releaseEvidence, {
+      faultCase,
+      requestImpl: async () => {
+        requests += 1;
+        return cleanDraft;
+      },
+    });
+    assert.equal(result.ok, true, faultCase);
+    assert.equal(result.repair_attempt_count, 1, faultCase);
+    assert.equal(requests, 2, faultCase);
+    assert.ok(result.repair_attempts[0].issues.length > 0, faultCase);
+  }
+});
+
+test("quality report exposes audit limits, attempts, and production source identity", () => {
+  const report = qualityReportFromDraft(
+    {
+      ok: false,
+      needs_review: true,
+      release_items: [],
+      coverage: { needs_review: true, missing_required_count: 1 },
+      validation_attempt_count: 1,
+      repair_attempt_count: 0,
+      repair_attempts: [{ stage: "draft", repair_attempt: 0, ok: false }],
+    },
+    {
+      targetVersion: "0.1.20",
+      previousTag: "v0.1.19",
+      currentTag: "v0.1.20",
+      currentRef: "HEAD",
+      faultCase: "missing_source_refs",
+    },
+  );
+
+  assert.equal(PRODUCT_ID, "openclaw-cloud-plugin");
+  assert.equal(report.product_id, PRODUCT_ID);
+  assert.equal(report.limits.max_items, 12);
+  assert.equal(report.fault_case, "missing_source_refs");
+  assert.equal(report.ok, false);
+  assert.equal(report.validation_attempt_count, 1);
+  assert.ok(report.issues.some((issue) => issue.kind === "empty_release_items"));
+});
+
 test("manual notes require bilingual evidence refs and passed coverage", () => {
   const valid = `## Changelog
 
@@ -696,22 +925,38 @@ test("manual notes require bilingual evidence refs and passed coverage", () => {
   );
 });
 
+test("manual cloud release notes cannot bypass docs readability validation", () => {
+  assert.throws(
+    () =>
+      validateManualNotes(`## Changelog
+
+### Improved
+- noisy cloud release note
+
+<!-- doc-agent-release-notes-json
+{"items":[{"category":"Improved","text_cn":"**云插件优化**：${"用于发布说明质量验证的重复中文描述。".repeat(12)}","text_en":"**Cloud plugin improvement**: ${"This repeated English detail is intentionally too verbose for a changelog bullet. ".repeat(6)}","source_refs":["abc1234"]}],"coverage":{"needs_review":false}}
+-->`),
+    /concise enough/,
+  );
+});
+
 test("manual release notes also produce docs preview outputs", async () => {
   const directory = mkdtempSync(join(tmpdir(), "cloud-plugin-manual-preview-"));
   const previous = { ...process.env };
   try {
     const outputPath = join(directory, "github-output.txt");
     const notesPath = join(directory, "release-notes.md");
+    const sourceRef = runGit(process.cwd(), ["rev-parse", "--short", "HEAD"]);
     Object.assign(process.env, {
       RELEASE_VERSION: "0.1.20",
       RELEASE_NOTES_FILE: notesPath,
       MANUAL_RELEASE_NOTES: `## Changelog
 
 ### Improved
-- **系统事件过滤增强**：自动跳过定时任务、计划提醒和后台命令结果，减少记忆污染。
+- **发布预览护栏**：增强云插件发布前的检查信息。
 
 <!-- doc-agent-release-notes-json
-{"items":[{"category":"Improved","text_cn":"**系统事件过滤增强**：自动跳过定时任务、计划提醒和后台命令结果，减少记忆污染。","text_en":"**System-event filtering**: Skips scheduled tasks, reminders, and background command results to keep memory cleaner.","source_refs":["d053b0a"]}],"coverage":{"needs_review":false,"required_count":1,"covered_required_count":1,"missing_required_count":0}}
+{"items":[{"category":"Improved","text_cn":"**发布预览护栏**：增强云插件发布前的检查信息。","text_en":"**Release preview guardrails**: Improves pre-publish inspection details for the cloud plugin.","source_refs":["${sourceRef}"]}],"coverage":{"needs_review":false,"required_count":0,"covered_required_count":0,"missing_required_count":0}}
 -->`,
       GITHUB_OUTPUT: outputPath,
     });
@@ -724,8 +969,51 @@ test("manual release notes also produce docs preview outputs", async () => {
     const preview = readFileSync(match[1], "utf8");
     assert.match(preview, /MemOS-Docs Plugin Changelog Preview/);
     assert.match(preview, /OpenClaw 云插件/);
-    assert.match(preview, /System-event filtering/);
+    assert.match(preview, /Release preview guardrails/);
     assert.match(readFileSync(notesPath, "utf8"), /doc-agent: source-id=openclaw-cloud-plugin/);
+    const qualityMatch = output.match(
+      /quality_report_file<<__DOC_AGENT_EOF__\n([\s\S]*?)\n__DOC_AGENT_EOF__/,
+    );
+    assert.ok(qualityMatch, "quality report output should be written");
+    const quality = JSON.parse(readFileSync(qualityMatch[1], "utf8"));
+    assert.equal(quality.ok, true);
+    assert.equal(quality.validation_attempt_count, 1);
+  } finally {
+    process.env = previous;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("manual release notes fail closed when source_refs are absent from real evidence", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "cloud-plugin-manual-invalid-ref-"));
+  const previous = { ...process.env };
+  try {
+    const outputPath = join(directory, "github-output.txt");
+    Object.assign(process.env, {
+      RELEASE_VERSION: "0.1.20",
+      RELEASE_NOTES_FILE: join(directory, "release-notes.md"),
+      MANUAL_RELEASE_NOTES: `## Changelog
+
+### Improved
+- invalid evidence reference
+
+<!-- doc-agent-release-notes-json
+{"items":[{"category":"Improved","text_cn":"**发布预览护栏**：增强云插件发布前的检查信息。","text_en":"**Release preview guardrails**: Improves pre-publish inspection details for the cloud plugin.","source_refs":["deadbeef"]}],"coverage":{"needs_review":false}}
+-->`,
+      GITHUB_OUTPUT: outputPath,
+    });
+
+    await assert.rejects(main(), /Postprocessed release notes require review/);
+
+    const output = readFileSync(outputPath, "utf8");
+    const qualityMatch = output.match(
+      /quality_report_file<<__DOC_AGENT_EOF__\n([\s\S]*?)\n__DOC_AGENT_EOF__/,
+    );
+    assert.ok(qualityMatch, "failed manual notes should still write a quality report");
+    const quality = JSON.parse(readFileSync(qualityMatch[1], "utf8"));
+    assert.equal(quality.ok, false);
+    assert.equal(quality.invalid_item_ref_count, 1);
+    assert.ok(quality.issues.some((issue) => issue.kind === "invalid_source_ref"));
   } finally {
     process.env = previous;
     rmSync(directory, { recursive: true, force: true });

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -665,7 +665,7 @@ test("manual notes require bilingual evidence refs and passed coverage", () => {
 - cloud memory
 
 <!-- doc-agent-release-notes-json
-{"items":[{"text_cn":"云端记忆","text_en":"Cloud memory","source_refs":["abc1234"]}],"coverage":{"needs_review":false}}
+{"items":[{"category":"Added","text_cn":"云端记忆","text_en":"Cloud memory","source_refs":["abc1234"]}],"coverage":{"needs_review":false}}
 -->`;
   assert.equal(validateManualNotes(valid), valid);
   assert.match(ensureSourceHint(valid), /source-id=openclaw-cloud-plugin/);
@@ -678,7 +678,19 @@ test("manual notes require bilingual evidence refs and passed coverage", () => {
 - cloud memory
 
 <!-- doc-agent-release-notes-json
-{"items":[{"text_cn":"Cloud memory","text_en":"云端记忆","source_refs":["abc1234"]}],"coverage":{"needs_review":false}}
+{"items":[{"text_cn":"云端记忆","text_en":"Cloud memory","source_refs":["abc1234"]}],"coverage":{"needs_review":false}}
+-->`),
+    /category, text_cn, text_en, and valid source_refs/,
+  );
+  assert.throws(
+    () =>
+      validateManualNotes(`## Changelog
+
+### Added
+- cloud memory
+
+<!-- doc-agent-release-notes-json
+{"items":[{"category":"Added","text_cn":"Cloud memory","text_en":"云端记忆","source_refs":["abc1234"]}],"coverage":{"needs_review":false}}
 -->`),
     /text_cn must contain Chinese/,
   );

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -259,6 +259,51 @@ test("postprocesses duplicate source refs into the best evidence category", () =
   assert.match(processed.release_notes_markdown, /doc-agent-release-notes-json/);
 });
 
+test("normalizes full and short SHA aliases while preserving a real PR ref", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Added",
+          text_cn: "**插件健康看板**：新增云插件健康状态展示。",
+          text_en: "**Plugin health dashboard**: Adds cloud plugin health status visibility.",
+          source_refs: [
+            "abc1234",
+            `abc1234${"0".repeat(33)}`,
+            "#3001",
+          ],
+        },
+      ],
+      coverage: { needs_review: false },
+      warnings: [],
+    },
+    {
+      commits: [
+        {
+          sha: `abc1234${"0".repeat(33)}`,
+          short_sha: "abc1234",
+          subject: "feat: add plugin health dashboard (#3001)",
+        },
+      ],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Added",
+            source_refs: ["abc1234", "#3001"],
+            subject: "feat: add plugin health dashboard (#3001)",
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.deepEqual(processed.release_items[0].source_refs, ["abc1234", "#3001"]);
+  assert.equal(processed.postprocess.removed_duplicate_source_refs, 1);
+});
+
 test("rewrites known system prompt handling evidence into docs-ready cloud plugin bullets", () => {
   const processed = postprocessDraftFromEvidence(
     {

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 attempts="${RETRY_ATTEMPTS:-3}"
 delay="${RETRY_DELAY_SECONDS:-5}"
+max_delay="${RETRY_MAX_DELAY_SECONDS:-60}"
 label="command"
 
 while [ "$#" -gt 0 ]; do
@@ -13,6 +14,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --delay)
       delay="$2"
+      shift 2
+      ;;
+    --max-delay)
+      max_delay="$2"
       shift 2
       ;;
     --label)
@@ -44,6 +49,11 @@ if ! [[ "${delay}" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+if ! [[ "${max_delay}" =~ ^[0-9]+$ ]]; then
+  echo "::error::Invalid retry max delay: ${max_delay}" >&2
+  exit 2
+fi
+
 for attempt in $(seq 1 "${attempts}"); do
   echo "::group::${label} attempt ${attempt}/${attempts}" >&2
   set +e
@@ -61,7 +71,20 @@ for attempt in $(seq 1 "${attempts}"); do
     exit "${status}"
   fi
 
-  sleep_seconds=$((delay * attempt))
+  base_sleep=$((delay * (2 ** (attempt - 1))))
+  if [ "${base_sleep}" -gt "${max_delay}" ]; then
+    base_sleep="${max_delay}"
+  fi
+
+  jitter=0
+  if [ "${base_sleep}" -gt 0 ]; then
+    jitter=$((RANDOM % (base_sleep + 1)))
+  fi
+  sleep_seconds=$((base_sleep + jitter))
+  if [ "${sleep_seconds}" -gt "${max_delay}" ]; then
+    sleep_seconds="${max_delay}"
+  fi
+
   echo "::warning::${label} failed with exit code ${status}; retrying in ${sleep_seconds}s." >&2
   sleep "${sleep_seconds}"
 done

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 attempts="${RETRY_ATTEMPTS:-3}"
 delay="${RETRY_DELAY_SECONDS:-5}"
 max_delay="${RETRY_MAX_DELAY_SECONDS:-60}"
+attempt_dir="${RETRY_ATTEMPT_DIR:-}"
 label="command"
 
 while [ "$#" -gt 0 ]; do
@@ -54,11 +55,21 @@ if ! [[ "${max_delay}" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+if [ -n "${attempt_dir}" ]; then
+  mkdir -p "${attempt_dir}"
+fi
+
 for attempt in $(seq 1 "${attempts}"); do
   echo "::group::${label} attempt ${attempt}/${attempts}" >&2
   set +e
-  "$@"
-  status=$?
+  if [ -n "${attempt_dir}" ]; then
+    "$@" >"${attempt_dir}/${attempt}.log" 2>&1
+    status=$?
+    sed -n '1,160p' "${attempt_dir}/${attempt}.log"
+  else
+    "$@"
+    status=$?
+  fi
   set -e
   echo "::endgroup::" >&2
 

--- a/.github/scripts/retry.test.mjs
+++ b/.github/scripts/retry.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const script = join(dirname(fileURLToPath(import.meta.url)), "retry.sh");
+
+test("captures one bounded log per retry attempt", () => {
+  const directory = mkdtempSync(join(tmpdir(), "cloud-plugin-retry-"));
+  const attemptDirectory = join(directory, "attempts");
+  const counter = join(directory, "counter");
+  try {
+    execFileSync(
+      "bash",
+      [
+        script,
+        "--attempts",
+        "3",
+        "--delay",
+        "0",
+        "--max-delay",
+        "0",
+        "--label",
+        "captured retry",
+        "--",
+        "bash",
+        "-c",
+        'count=0; [ ! -f "$1" ] || count="$(tr -d \'[:space:]\' <"$1")"; count=$((count + 1)); printf \'%s\\n\' "$count" >"$1"; printf \'attempt %s\\n\' "$count"; [ "$count" -ge 3 ]',
+        "retry-attempt",
+        counter,
+      ],
+      {
+        env: { ...process.env, RETRY_ATTEMPT_DIR: attemptDirectory },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    assert.equal(readFileSync(counter, "utf8").trim(), "3");
+    assert.equal(readFileSync(join(attemptDirectory, "1.log"), "utf8").trim(), "attempt 1");
+    assert.equal(readFileSync(join(attemptDirectory, "2.log"), "utf8").trim(), "attempt 2");
+    assert.equal(readFileSync(join(attemptDirectory, "3.log"), "utf8").trim(), "attempt 3");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("preserves the final command exit code while retaining exhausted-attempt logs", () => {
+  const directory = mkdtempSync(join(tmpdir(), "cloud-plugin-retry-failure-"));
+  try {
+    const result = spawnSync(
+      "bash",
+      [
+        script,
+        "--attempts",
+        "3",
+        "--delay",
+        "0",
+        "--max-delay",
+        "0",
+        "--label",
+        "failed retry",
+        "--",
+        "bash",
+        "-c",
+        'printf "retry failed\\n"; exit 7',
+      ],
+      {
+        env: { ...process.env, RETRY_ATTEMPT_DIR: directory },
+        encoding: "utf8",
+      },
+    );
+    assert.equal(result.status, 7);
+    for (const attempt of [1, 2, 3]) {
+      assert.equal(readFileSync(join(directory, `${attempt}.log`), "utf8").trim(), "retry failed");
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/validate-github-release-inventory.mjs
+++ b/.github/scripts/validate-github-release-inventory.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const DOC_AGENT_SOURCE_ID = "openclaw-cloud-plugin";
+
+function releasePages(value) {
+  if (!Array.isArray(value)) return [];
+  if (value.every((item) => Array.isArray(item))) return value;
+  return [value];
+}
+
+export function flattenReleasePages(value) {
+  return releasePages(value)
+    .flat()
+    .filter((item) => item && typeof item === "object");
+}
+
+export function docAgentSourceIds(body) {
+  return [
+    ...String(body || "").matchAll(
+      /<!--\s*doc-agent:\s*source-id=([A-Za-z0-9._-]+)\s*-->/g,
+    ),
+  ].map((match) => match[1]);
+}
+
+function releaseSummary(release) {
+  return {
+    id: Number(release?.id || 0),
+    tag_name: String(release?.tag_name || ""),
+    draft: Boolean(release?.draft),
+    prerelease: Boolean(release?.prerelease),
+    target_commitish: String(release?.target_commitish || ""),
+    created_at: String(release?.created_at || ""),
+  };
+}
+
+export function inspectReleaseInventory({
+  pages,
+  tag,
+  expectedDraft,
+  expectedPrerelease,
+  expectedTargetCommitish,
+  requiredSourceId = DOC_AGENT_SOURCE_ID,
+  requireExisting = false,
+} = {}) {
+  const releaseTag = String(tag || "").trim();
+  const matches = flattenReleasePages(pages).filter(
+    (release) => String(release?.tag_name || "").trim() === releaseTag,
+  );
+  const summaries = matches.map(releaseSummary);
+  const errors = [];
+
+  if (!releaseTag) {
+    errors.push("release tag is required");
+  }
+  if (matches.length === 0) {
+    if (requireExisting) {
+      errors.push(`GitHub Release ${releaseTag} was not visible after creation`);
+    }
+    return {
+      ok: errors.length === 0,
+      state: "absent",
+      tag: releaseTag,
+      count: 0,
+      releases: [],
+      errors,
+    };
+  }
+  if (matches.length > 1) {
+    errors.push(
+      `found ${matches.length} GitHub Releases for ${releaseTag}; refusing ambiguous release metadata`,
+    );
+    return {
+      ok: false,
+      state: "ambiguous",
+      tag: releaseTag,
+      count: matches.length,
+      releases: summaries,
+      errors,
+    };
+  }
+
+  const release = matches[0];
+  if (
+    typeof expectedDraft === "boolean" &&
+    Boolean(release.draft) !== expectedDraft
+  ) {
+    errors.push(
+      `GitHub Release ${releaseTag} draft=${Boolean(release.draft)}, expected ${expectedDraft}`,
+    );
+  }
+  if (
+    typeof expectedPrerelease === "boolean" &&
+    Boolean(release.prerelease) !== expectedPrerelease
+  ) {
+    errors.push(
+      `GitHub Release ${releaseTag} prerelease=${Boolean(release.prerelease)}, expected ${expectedPrerelease}`,
+    );
+  }
+  const expectedTarget = String(expectedTargetCommitish || "").trim();
+  if (
+    expectedTarget &&
+    String(release.target_commitish || "").trim() !== expectedTarget
+  ) {
+    errors.push(
+      `GitHub Release ${releaseTag} targets ${String(release.target_commitish || "")}, expected ${expectedTarget}`,
+    );
+  }
+
+  const expectedSourceId = String(requiredSourceId || "").trim();
+  const sourceIds = docAgentSourceIds(release.body);
+  if (
+    expectedSourceId &&
+    (sourceIds.length !== 1 || sourceIds[0] !== expectedSourceId)
+  ) {
+    errors.push(
+      `GitHub Release ${releaseTag} must contain exactly one Doc Agent source id ${expectedSourceId}; found ${sourceIds.join(", ") || "none"}`,
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    state: "existing",
+    tag: releaseTag,
+    count: 1,
+    releases: summaries,
+    errors,
+  };
+}
+
+function required(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function parseBoolean(name) {
+  const value = required(name);
+  if (!["true", "false"].includes(value)) {
+    throw new Error(`${name} must be true or false`);
+  }
+  return value === "true";
+}
+
+export function main() {
+  const pages = JSON.parse(
+    readFileSync(required("RELEASE_INVENTORY_FILE"), "utf8"),
+  );
+  const report = inspectReleaseInventory({
+    pages,
+    tag: required("RELEASE_TAG"),
+    expectedDraft: parseBoolean("EXPECTED_RELEASE_DRAFT"),
+    expectedPrerelease: parseBoolean("EXPECTED_RELEASE_PRERELEASE"),
+    expectedTargetCommitish: String(
+      process.env.EXPECTED_RELEASE_TARGET || "",
+    ).trim(),
+    requiredSourceId:
+      String(process.env.REQUIRED_DOC_AGENT_SOURCE_ID || "").trim() ||
+      DOC_AGENT_SOURCE_ID,
+    requireExisting:
+      String(process.env.REQUIRE_EXISTING_RELEASE || "false").trim() === "true",
+  });
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+  if (!report.ok) process.exitCode = 1;
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  try {
+    main();
+  } catch (error) {
+    console.error(String(error?.message || error));
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -180,6 +180,15 @@ test("real publishes are branch-gated and reusable callers are immutable dry run
 });
 
 test("dry-run callers use least privilege and do not inherit all repository secrets", () => {
+  const releaseWorkflow = readFileSync(
+    new URL("../workflows/release.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    releaseWorkflow,
+    /NPM_TOKEN:\s*\n\s*description:[^\n]*\n\s*required: false/,
+  );
+
   const preMerge = readFileSync(
     new URL("../workflows/pre-merge-dry-run.yml", import.meta.url),
     "utf8",

--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  DOC_AGENT_SOURCE_ID,
+  docAgentSourceIds,
+  inspectReleaseInventory,
+} from "./validate-github-release-inventory.mjs";
+
+function release(overrides = {}) {
+  return {
+    id: 149,
+    tag_name: "v0.1.20",
+    draft: false,
+    prerelease: false,
+    target_commitish: "abc123",
+    body: `## Changelog\n\n<!-- doc-agent: source-id=${DOC_AGENT_SOURCE_ID} -->`,
+    created_at: "2026-07-27T00:00:00Z",
+    ...overrides,
+  };
+}
+
+test("extracts exact Doc Agent source ids", () => {
+  assert.deepEqual(
+    docAgentSourceIds(
+      "<!-- doc-agent: source-id=openclaw-cloud-plugin -->\n<!-- doc-agent: source-id=other -->",
+    ),
+    ["openclaw-cloud-plugin", "other"],
+  );
+});
+
+test("accepts an absent release unless post-create verification requires it", () => {
+  const absent = inspectReleaseInventory({
+    pages: [[]],
+    tag: "v0.1.20",
+    expectedDraft: false,
+    expectedPrerelease: false,
+  });
+  assert.equal(absent.ok, true);
+  assert.equal(absent.state, "absent");
+
+  const required = inspectReleaseInventory({
+    pages: [[]],
+    tag: "v0.1.20",
+    expectedDraft: false,
+    expectedPrerelease: false,
+    requireExisting: true,
+  });
+  assert.equal(required.ok, false);
+  assert.match(required.errors[0], /not visible/);
+});
+
+test("fails closed on duplicate releases including drafts", () => {
+  const report = inspectReleaseInventory({
+    pages: [[release(), release({ id: 150, draft: true })]],
+    tag: "v0.1.20",
+    expectedDraft: false,
+    expectedPrerelease: false,
+  });
+  assert.equal(report.ok, false);
+  assert.equal(report.state, "ambiguous");
+  assert.match(report.errors[0], /2 GitHub Releases/);
+});
+
+test("verifies target, release flags, and the exact production source id", () => {
+  const valid = inspectReleaseInventory({
+    pages: [[release()]],
+    tag: "v0.1.20",
+    expectedDraft: false,
+    expectedPrerelease: false,
+    expectedTargetCommitish: "abc123",
+  });
+  assert.equal(valid.ok, true);
+
+  const invalid = inspectReleaseInventory({
+    pages: [[
+      release({
+        draft: true,
+        prerelease: true,
+        target_commitish: "wrong",
+        body:
+          "<!-- doc-agent: source-id=openclaw-cloud-plugin -->\n" +
+          "<!-- doc-agent: source-id=test-openclaw-cloud-plugin -->",
+      }),
+    ]],
+    tag: "v0.1.20",
+    expectedDraft: false,
+    expectedPrerelease: false,
+    expectedTargetCommitish: "abc123",
+  });
+  assert.equal(invalid.ok, false);
+  assert.equal(invalid.errors.length, 4);
+  assert.ok(invalid.errors.some((error) => /draft=true/.test(error)));
+  assert.ok(invalid.errors.some((error) => /prerelease=true/.test(error)));
+  assert.ok(invalid.errors.some((error) => /targets wrong/.test(error)));
+  assert.ok(invalid.errors.some((error) => /exactly one Doc Agent source id/.test(error)));
+});
+
+test("release workflow pins recovery to npm gitHead and reconciles create responses", () => {
+  const workflow = readFileSync(
+    new URL("../workflows/release.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(workflow, /npm_release_git_head\(\)/);
+  assert.match(
+    workflow,
+    /RELEASE_EVIDENCE_REF: \$\{\{ steps\.release_source\.outputs\.evidence_ref \}\}/,
+  );
+  assert.match(
+    workflow,
+    /release evidence is pinned to npm gitHead/,
+  );
+  assert.match(
+    workflow,
+    /missing GitHub metadata will target npm gitHead \$\{release_commit_sha\}/,
+  );
+  assert.match(
+    workflow,
+    /git tag -a "\$\{release_tag\}" "\$\{RELEASE_COMMIT_SHA\}"/,
+  );
+  assert.match(workflow, /push durable release branch/);
+  assert.ok(
+    workflow.indexOf("push durable release branch") <
+      workflow.indexOf('npm publish --access public --tag "${NPM_DIST_TAG}"'),
+    "the recoverable release commit must be pushed before npm publish",
+  );
+  assert.match(
+    workflow,
+    /--target "\$\{RELEASE_COMMIT_SHA\}"/,
+  );
+  assert.match(workflow, /gh api --paginate --slurp/);
+  assert.match(
+    workflow,
+    /Refusing to issue a second create request/,
+  );
+  assert.doesNotMatch(workflow, /gh release view/);
+});
+
+test("real publishes are branch-gated and dry-run callers have read-only contents", () => {
+  const releaseWorkflow = readFileSync(
+    new URL("../workflows/release.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    releaseWorkflow,
+    /Real releases must be dispatched from the protected default branch/,
+  );
+
+  for (const name of [
+    "pre-merge-dry-run.yml",
+    "post-merge-dry-run.yml",
+    "historical-dry-run.yml",
+  ]) {
+    const workflow = readFileSync(
+      new URL(`../workflows/${name}`, import.meta.url),
+      "utf8",
+    );
+    assert.match(workflow, /permissions:\n  contents: read/);
+    assert.doesNotMatch(workflow, /contents: write/);
+    assert.doesNotMatch(workflow, /pull-requests: write/);
+  }
+});

--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -134,6 +134,24 @@ test("release workflow pins recovery to npm gitHead and reconciles create respon
     workflow,
     /Refusing to issue a second create request/,
   );
+  assert.match(workflow, /report_exhausted_failure "github-release-create"/);
+  assert.match(workflow, /report_exhausted_failure "github-release-verification"/);
+  assert.match(workflow, /report_exhausted_failure "github-release-tag-push"/);
+  assert.match(workflow, /report_exhausted_failure "github-release-branch-push"/);
+  assert.match(workflow, /report_exhausted_failure "github-release-pr-create"/);
+  assert.match(workflow, /should_create_version_pr=true/);
+  assert.match(
+    workflow,
+    /Release branch \$\{release_branch\} already points at this commit\.[\s\S]+should_create_version_pr=true/,
+  );
+  assert.match(
+    workflow,
+    /::error::Failed to create release PR automatically after three attempts/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /::warning::Failed to create release PR automatically after three attempts/,
+  );
   assert.doesNotMatch(workflow, /gh release view/);
 });
 

--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -184,16 +184,31 @@ test("dry-run callers use least privilege and do not inherit all repository secr
     new URL("../workflows/release.yml", import.meta.url),
     "utf8",
   );
+  const dryRunWorkflow = readFileSync(
+    new URL("../workflows/release-dry-run.yml", import.meta.url),
+    "utf8",
+  );
+  assert.doesNotMatch(releaseWorkflow, /workflow_call:/);
+  assert.match(releaseWorkflow, /NODE_AUTH_TOKEN: \$\{\{ secrets\.NPM_TOKEN \}\}/);
   assert.match(
     releaseWorkflow,
-    /NPM_TOKEN:\s*\n\s*description:[^\n]*\n\s*required: false/,
+    /persist-credentials: \$\{\{ inputs\.dry_run != true \}\}/,
   );
+  assert.match(dryRunWorkflow, /workflow_call:/);
+  assert.match(dryRunWorkflow, /permissions:\s*\n\s*contents: read/);
+  assert.match(dryRunWorkflow, /persist-credentials: false/);
+  assert.doesNotMatch(dryRunWorkflow, /NPM_TOKEN/);
+  assert.doesNotMatch(dryRunWorkflow, /npm publish/);
+  assert.doesNotMatch(dryRunWorkflow, /gh release/);
+  assert.doesNotMatch(dryRunWorkflow, /contents: write/);
+  assert.doesNotMatch(dryRunWorkflow, /pull-requests: write/);
 
   const preMerge = readFileSync(
     new URL("../workflows/pre-merge-dry-run.yml", import.meta.url),
     "utf8",
   );
   assert.match(preMerge, /permissions:\s*\n\s*contents: read/);
+  assert.match(preMerge, /uses: \.\/\.github\/workflows\/release-dry-run\.yml/);
   assert.match(preMerge, /release_notes: \|/);
   assert.match(preMerge, /doc-agent-release-notes-json/);
   assert.doesNotMatch(preMerge, /\$\{\{\s*secrets\./);
@@ -210,6 +225,7 @@ test("dry-run callers use least privilege and do not inherit all repository secr
       "utf8",
     );
     assert.match(workflow, /permissions:\s*\n(?:\s*#[^\n]*\n)*\s*contents: read/);
+    assert.match(workflow, /uses: \.\/\.github\/workflows\/release-dry-run\.yml/);
     assert.doesNotMatch(workflow, /secrets: inherit/);
     assert.doesNotMatch(workflow, /NPM_TOKEN/);
     assert.doesNotMatch(workflow, /contents: write/);

--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -137,7 +137,7 @@ test("release workflow pins recovery to npm gitHead and reconciles create respon
   assert.doesNotMatch(workflow, /gh release view/);
 });
 
-test("real publishes are branch-gated and dry-run callers have read-only contents", () => {
+test("real publishes are branch-gated and reusable callers are immutable dry runs", () => {
   const releaseWorkflow = readFileSync(
     new URL("../workflows/release.yml", import.meta.url),
     "utf8",
@@ -156,8 +156,7 @@ test("real publishes are branch-gated and dry-run callers have read-only content
       new URL(`../workflows/${name}`, import.meta.url),
       "utf8",
     );
-    assert.match(workflow, /permissions:\n  contents: read/);
-    assert.doesNotMatch(workflow, /contents: write/);
-    assert.doesNotMatch(workflow, /pull-requests: write/);
+    assert.match(workflow, /dry_run: true/);
+    assert.doesNotMatch(workflow, /dry_run: false/);
   }
 });

--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -237,4 +237,38 @@ test("dry-run callers use least privilege and do not inherit all repository secr
     "utf8",
   );
   assert.match(historical, /github\.event\.repository\.default_branch/);
+  for (const [version, previousTag] of [
+    ["0.1.15", "v0.1.14"],
+    ["0.1.16", "v0.1.15"],
+    ["0.1.17", "v0.1.16"],
+    ["0.1.18", "v0.1.17"],
+    ["0.1.19", "v0.1.18"],
+  ]) {
+    assert.match(
+      historical,
+      new RegExp(
+        `version: "${version.replaceAll(".", "\\.")}"\\s+expected_previous_tag: "${previousTag.replaceAll(".", "\\.")}"\\s+expected_current_ref: "v${version.replaceAll(".", "\\.")}"`,
+      ),
+    );
+  }
+
+  const contractLint = readFileSync(
+    new URL("../workflows/workflow-contract-lint.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(contractLint, /permissions:\s*\n\s*contents: read/);
+  assert.match(contractLint, /persist-credentials: false/);
+  assert.match(contractLint, /ACTIONLINT_VERSION: "1\.7\.12"/);
+  assert.match(
+    contractLint,
+    /ACTIONLINT_LINUX_AMD64_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"/,
+  );
+  assert.match(
+    contractLint,
+    /node --test \.github\/scripts\/validate-github-release-inventory\.test\.mjs/,
+  );
+  assert.doesNotMatch(contractLint, /secrets:/);
+  assert.doesNotMatch(contractLint, /contents: write/);
+  assert.doesNotMatch(contractLint, /pull-requests: write/);
+  assert.doesNotMatch(contractLint, /uses: \.\/\.github\/workflows\/release/);
 });

--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -178,3 +178,38 @@ test("real publishes are branch-gated and reusable callers are immutable dry run
     assert.doesNotMatch(workflow, /dry_run: false/);
   }
 });
+
+test("dry-run callers use least privilege and do not inherit all repository secrets", () => {
+  const preMerge = readFileSync(
+    new URL("../workflows/pre-merge-dry-run.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(preMerge, /permissions:\s*\n\s*contents: read/);
+  assert.match(preMerge, /release_notes: \|/);
+  assert.match(preMerge, /doc-agent-release-notes-json/);
+  assert.doesNotMatch(preMerge, /\$\{\{\s*secrets\./);
+  assert.doesNotMatch(preMerge, /secrets: inherit/);
+  assert.doesNotMatch(preMerge, /contents: write/);
+  assert.doesNotMatch(preMerge, /pull-requests: write/);
+
+  for (const name of [
+    "post-merge-dry-run.yml",
+    "historical-dry-run.yml",
+  ]) {
+    const workflow = readFileSync(
+      new URL(`../workflows/${name}`, import.meta.url),
+      "utf8",
+    );
+    assert.match(workflow, /permissions:\s*\n(?:\s*#[^\n]*\n)*\s*contents: read/);
+    assert.doesNotMatch(workflow, /secrets: inherit/);
+    assert.doesNotMatch(workflow, /NPM_TOKEN/);
+    assert.doesNotMatch(workflow, /contents: write/);
+    assert.doesNotMatch(workflow, /pull-requests: write/);
+  }
+
+  const historical = readFileSync(
+    new URL("../workflows/historical-dry-run.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(historical, /github\.event\.repository\.default_branch/);
+});

--- a/.github/scripts/validate-release-confirmation.mjs
+++ b/.github/scripts/validate-release-confirmation.mjs
@@ -1,8 +1,49 @@
 #!/usr/bin/env node
 
+import { cleanVersion, parseSemver } from "../../lib/semver.js";
+
 export function expectedReleaseConfirmation(version) {
-  const cleanVersion = String(version || "").trim().replace(/^[vV]/, "");
-  return `PUBLISH v${cleanVersion}`;
+  const versionWithoutPrefix = cleanVersion(version);
+  return `PUBLISH v${versionWithoutPrefix}`;
+}
+
+export function validateReleaseChannel({ version, npmDistTag }) {
+  const parsed = parseSemver(version);
+  const tag = String(npmDistTag || "").trim();
+  if (!parsed) {
+    return {
+      ok: false,
+      reason: `version must be a valid SemVer value; got '${String(version || "").trim()}'.`,
+    };
+  }
+  if (!tag) {
+    return { ok: false, reason: "npm dist-tag is required." };
+  }
+
+  const isPrerelease = parsed.prerelease.length > 0;
+  if (isPrerelease && tag === "latest") {
+    return {
+      ok: false,
+      reason:
+        `prerelease version ${cleanVersion(version)} cannot use npm dist-tag 'latest'; ` +
+        "use beta, next, alpha, or another non-latest preview channel.",
+    };
+  }
+  if (!isPrerelease && tag !== "latest") {
+    return {
+      ok: false,
+      reason:
+        `stable version ${cleanVersion(version)} must use npm dist-tag 'latest'; ` +
+        `got '${tag}'. This workflow does not support promoting a stable version from '${tag}' later.`,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: isPrerelease
+      ? `prerelease version and npm dist-tag '${tag}' are compatible.`
+      : "stable version and npm dist-tag 'latest' are compatible.",
+  };
 }
 
 export function validateReleaseConfirmation({ version, dryRun, confirmation }) {
@@ -35,6 +76,14 @@ export function validateReleaseConfirmation({ version, dryRun, confirmation }) {
 }
 
 export function main(env = process.env) {
+  const channel = validateReleaseChannel({
+    version: env.RELEASE_VERSION,
+    npmDistTag: env.NPM_DIST_TAG,
+  });
+  if (!channel.ok) {
+    throw new Error(channel.reason);
+  }
+
   const result = validateReleaseConfirmation({
     version: env.RELEASE_VERSION,
     dryRun: env.DRY_RUN,
@@ -45,6 +94,7 @@ export function main(env = process.env) {
     throw new Error(result.reason);
   }
 
+  console.log(channel.reason);
   console.log(result.reason);
   if (result.expected) {
     console.log(`Expected confirmation: ${result.expected}`);

--- a/.github/scripts/validate-release-confirmation.mjs
+++ b/.github/scripts/validate-release-confirmation.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+export function expectedReleaseConfirmation(version) {
+  const cleanVersion = String(version || "").trim().replace(/^[vV]/, "");
+  return `PUBLISH v${cleanVersion}`;
+}
+
+export function validateReleaseConfirmation({ version, dryRun, confirmation }) {
+  const isDryRun = String(dryRun ?? "true").trim().toLowerCase() === "true";
+  const expected = expectedReleaseConfirmation(version);
+
+  if (isDryRun) {
+    return {
+      ok: true,
+      expected,
+      reason: "dry_run=true; publish confirmation is not required.",
+    };
+  }
+
+  if (String(confirmation || "").trim() === expected) {
+    return {
+      ok: true,
+      expected,
+      reason: "publish confirmation accepted.",
+    };
+  }
+
+  return {
+    ok: false,
+    expected,
+    reason:
+      "dry_run=false would publish to npm and create a published GitHub Release; " +
+      `publish_confirmation must exactly equal '${expected}'.`,
+  };
+}
+
+export function main(env = process.env) {
+  const result = validateReleaseConfirmation({
+    version: env.RELEASE_VERSION,
+    dryRun: env.DRY_RUN,
+    confirmation: env.PUBLISH_CONFIRMATION,
+  });
+
+  if (!result.ok) {
+    throw new Error(result.reason);
+  }
+
+  console.log(result.reason);
+  if (result.expected) {
+    console.log(`Expected confirmation: ${result.expected}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::${error?.message || String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/validate-release-confirmation.test.mjs
+++ b/.github/scripts/validate-release-confirmation.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   expectedReleaseConfirmation,
+  validateReleaseChannel,
   validateReleaseConfirmation,
 } from "./validate-release-confirmation.mjs";
 
@@ -20,6 +21,23 @@ test("does not require publish confirmation for dry runs", () => {
     }).ok,
     true,
   );
+});
+
+test("requires stable versions to use latest and prereleases to use a preview channel", () => {
+  assert.equal(validateReleaseChannel({ version: "0.1.20", npmDistTag: "latest" }).ok, true);
+  assert.equal(validateReleaseChannel({ version: "0.1.20-beta.1", npmDistTag: "beta" }).ok, true);
+  assert.equal(validateReleaseChannel({ version: "0.1.20-rc.1", npmDistTag: "next" }).ok, true);
+
+  const prereleaseOnLatest = validateReleaseChannel({
+    version: "0.1.20-beta.1",
+    npmDistTag: "latest",
+  });
+  assert.equal(prereleaseOnLatest.ok, false);
+  assert.match(prereleaseOnLatest.reason, /cannot use npm dist-tag 'latest'/);
+
+  const stableOnBeta = validateReleaseChannel({ version: "0.1.20", npmDistTag: "beta" });
+  assert.equal(stableOnBeta.ok, false);
+  assert.match(stableOnBeta.reason, /must use npm dist-tag 'latest'/);
 });
 
 test("requires exact publish confirmation before a real release", () => {

--- a/.github/scripts/validate-release-confirmation.test.mjs
+++ b/.github/scripts/validate-release-confirmation.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  expectedReleaseConfirmation,
+  validateReleaseConfirmation,
+} from "./validate-release-confirmation.mjs";
+
+test("builds the exact publish confirmation phrase from a version", () => {
+  assert.equal(expectedReleaseConfirmation("0.1.20"), "PUBLISH v0.1.20");
+  assert.equal(expectedReleaseConfirmation("v0.1.20-beta.1"), "PUBLISH v0.1.20-beta.1");
+});
+
+test("does not require publish confirmation for dry runs", () => {
+  assert.equal(
+    validateReleaseConfirmation({
+      version: "0.1.20",
+      dryRun: "true",
+      confirmation: "",
+    }).ok,
+    true,
+  );
+});
+
+test("requires exact publish confirmation before a real release", () => {
+  assert.equal(
+    validateReleaseConfirmation({
+      version: "0.1.20",
+      dryRun: "false",
+      confirmation: "",
+    }).ok,
+    false,
+  );
+  assert.equal(
+    validateReleaseConfirmation({
+      version: "0.1.20",
+      dryRun: "false",
+      confirmation: "PUBLISH 0.1.20",
+    }).ok,
+    false,
+  );
+  assert.equal(
+    validateReleaseConfirmation({
+      version: "0.1.20",
+      dryRun: "false",
+      confirmation: "PUBLISH v0.1.20",
+    }).ok,
+    true,
+  );
+});

--- a/.github/workflows/historical-dry-run.yml
+++ b/.github/workflows/historical-dry-run.yml
@@ -18,6 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - version: "0.1.15"
+            expected_previous_tag: "v0.1.14"
+            expected_current_ref: "v0.1.15"
           - version: "0.1.16"
             expected_previous_tag: "v0.1.15"
             expected_current_ref: "v0.1.16"

--- a/.github/workflows/historical-dry-run.yml
+++ b/.github/workflows/historical-dry-run.yml
@@ -30,7 +30,7 @@ jobs:
           - version: "0.1.19"
             expected_previous_tag: "v0.1.18"
             expected_current_ref: "v0.1.19"
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/release-dry-run.yml
     with:
       version: ${{ matrix.version }}
       tag: "latest"

--- a/.github/workflows/historical-dry-run.yml
+++ b/.github/workflows/historical-dry-run.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  # Must match the reusable release workflow; dry_run=true keeps every mutating
+  # publish, tag, Release, and PR step skipped.
+  contents: write
+  pull-requests: write
 
 jobs:
   historical-dry-run:

--- a/.github/workflows/historical-dry-run.yml
+++ b/.github/workflows/historical-dry-run.yml
@@ -1,0 +1,41 @@
+name: OpenClaw Cloud Plugin — Historical Dry Run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  historical-dry-run:
+    name: ${{ matrix.expected_previous_tag }}..${{ matrix.expected_current_ref }}
+    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: "0.1.16"
+            expected_previous_tag: "v0.1.15"
+            expected_current_ref: "v0.1.16"
+          - version: "0.1.17"
+            expected_previous_tag: "v0.1.16"
+            expected_current_ref: "v0.1.17"
+          - version: "0.1.18"
+            expected_previous_tag: "v0.1.17"
+            expected_current_ref: "v0.1.18"
+          - version: "0.1.19"
+            expected_previous_tag: "v0.1.18"
+            expected_current_ref: "v0.1.19"
+    uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ matrix.version }}
+      tag: "latest"
+      git_ref: ""
+      release_notes: ""
+      dry_run: true
+      recover_existing_npm_release: false
+      artifact_name: openclaw-cloud-plugin-release-inspection-${{ matrix.version }}
+      expected_previous_tag: ${{ matrix.expected_previous_tag }}
+      expected_current_ref: ${{ matrix.expected_current_ref }}
+    secrets: inherit

--- a/.github/workflows/historical-dry-run.yml
+++ b/.github/workflows/historical-dry-run.yml
@@ -4,8 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   historical-dry-run:

--- a/.github/workflows/historical-dry-run.yml
+++ b/.github/workflows/historical-dry-run.yml
@@ -4,15 +4,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  # Must match the reusable release workflow; dry_run=true keeps every mutating
-  # publish, tag, Release, and PR step skipped.
-  contents: write
-  pull-requests: write
+  # Historical integration may use Doc Agent secrets only from the protected
+  # default branch and never receives a write-capable token.
+  contents: read
 
 jobs:
   historical-dry-run:
     name: ${{ matrix.expected_previous_tag }}..${{ matrix.expected_current_ref }}
-    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
+    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -40,4 +41,10 @@ jobs:
       artifact_name: openclaw-cloud-plugin-release-inspection-${{ matrix.version }}
       expected_previous_tag: ${{ matrix.expected_previous_tag }}
       expected_current_ref: ${{ matrix.expected_current_ref }}
-    secrets: inherit
+    secrets:
+      DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
+      DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
+      DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
+      MEMOS_ARMS_ENDPOINT: ${{ secrets.MEMOS_ARMS_ENDPOINT }}
+      MEMOS_ARMS_PID: ${{ secrets.MEMOS_ARMS_PID }}
+      MEMOS_ARMS_ENV: ${{ secrets.MEMOS_ARMS_ENV }}

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - ".github/workflows/release.yml"
+      - ".github/workflows/historical-dry-run.yml"
       - ".github/workflows/pre-merge-dry-run.yml"
       - ".github/workflows/post-merge-dry-run.yml"
       - ".github/scripts/draft-cloud-plugin-release-notes.mjs"

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -11,6 +11,8 @@ on:
       - ".github/workflows/post-merge-dry-run.yml"
       - ".github/scripts/draft-cloud-plugin-release-notes.mjs"
       - ".github/scripts/draft-cloud-plugin-release-notes.test.mjs"
+      - ".github/scripts/validate-github-release-inventory.mjs"
+      - ".github/scripts/validate-github-release-inventory.test.mjs"
       - ".github/scripts/validate-release-confirmation.mjs"
       - ".github/scripts/validate-release-confirmation.test.mjs"
       - ".github/scripts/retry.sh"
@@ -21,8 +23,7 @@ on:
       - ".gitignore"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   dry-run:

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - ".github/workflows/release.yml"
+      - ".github/workflows/release-dry-run.yml"
       - ".github/workflows/historical-dry-run.yml"
       - ".github/workflows/pre-merge-dry-run.yml"
       - ".github/workflows/post-merge-dry-run.yml"
@@ -23,8 +24,8 @@ on:
       - ".gitignore"
 
 permissions:
-  # Trusted main integration still calls the real Doc Agent draft endpoint,
-  # but the reusable workflow cannot elevate this read-only token.
+  # Trusted main integration can call the Doc Agent draft endpoint, while the
+  # reusable inspection workflow keeps the GitHub token read-only.
   contents: read
 
 jobs:
@@ -32,7 +33,7 @@ jobs:
     if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
     permissions:
       contents: read
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/release-dry-run.yml
     with:
       version: "0.1.19"
       tag: "latest"

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/historical-dry-run.yml"
       - ".github/workflows/pre-merge-dry-run.yml"
       - ".github/workflows/post-merge-dry-run.yml"
+      - ".github/workflows/workflow-contract-lint.yml"
       - ".github/scripts/draft-cloud-plugin-release-notes.mjs"
       - ".github/scripts/draft-cloud-plugin-release-notes.test.mjs"
       - ".github/scripts/validate-github-release-inventory.mjs"

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -23,14 +23,15 @@ on:
       - ".gitignore"
 
 permissions:
-  # Must match the reusable release workflow; dry_run=true keeps every mutating
-  # publish, tag, Release, and PR step skipped.
-  contents: write
-  pull-requests: write
+  # Trusted main integration still calls the real Doc Agent draft endpoint,
+  # but the reusable workflow cannot elevate this read-only token.
+  contents: read
 
 jobs:
   dry-run:
     if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/release.yml
     with:
       version: "0.1.19"
@@ -39,4 +40,10 @@ jobs:
       release_notes: ""
       dry_run: true
       recover_existing_npm_release: false
-    secrets: inherit
+    secrets:
+      DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
+      DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
+      DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
+      MEMOS_ARMS_ENDPOINT: ${{ secrets.MEMOS_ARMS_ENDPOINT }}
+      MEMOS_ARMS_PID: ${{ secrets.MEMOS_ARMS_PID }}
+      MEMOS_ARMS_ENV: ${{ secrets.MEMOS_ARMS_ENV }}

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -11,6 +11,8 @@ on:
       - ".github/workflows/post-merge-dry-run.yml"
       - ".github/scripts/draft-cloud-plugin-release-notes.mjs"
       - ".github/scripts/draft-cloud-plugin-release-notes.test.mjs"
+      - ".github/scripts/validate-release-confirmation.mjs"
+      - ".github/scripts/validate-release-confirmation.test.mjs"
       - ".github/scripts/retry.sh"
       - "package.json"
       - "scripts/generate-telemetry-credentials.cjs"

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -23,7 +23,10 @@ on:
       - ".gitignore"
 
 permissions:
-  contents: read
+  # Must match the reusable release workflow; dry_run=true keeps every mutating
+  # publish, tag, Release, and PR step skipped.
+  contents: write
+  pull-requests: write
 
 jobs:
   dry-run:

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -23,7 +23,11 @@ on:
       - ".gitignore"
 
 permissions:
-  contents: read
+  # The reusable release workflow also serves real publishes and declares write
+  # permissions. GitHub does not allow a called workflow to elevate a read-only
+  # caller token, so safety here is enforced by the immutable dry_run=true input.
+  contents: write
+  pull-requests: write
 
 jobs:
   secrets-preflight:

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/historical-dry-run.yml"
       - ".github/workflows/pre-merge-dry-run.yml"
       - ".github/workflows/post-merge-dry-run.yml"
+      - ".github/workflows/workflow-contract-lint.yml"
       - ".github/scripts/draft-cloud-plugin-release-notes.mjs"
       - ".github/scripts/draft-cloud-plugin-release-notes.test.mjs"
       - ".github/scripts/validate-github-release-inventory.mjs"

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -6,6 +6,7 @@ on:
       - "docs-sync/**"
     paths:
       - ".github/workflows/release.yml"
+      - ".github/workflows/release-dry-run.yml"
       - ".github/workflows/historical-dry-run.yml"
       - ".github/workflows/pre-merge-dry-run.yml"
       - ".github/workflows/post-merge-dry-run.yml"
@@ -23,8 +24,8 @@ on:
       - ".gitignore"
 
 permissions:
-  # Branch code is intentionally validated without repository secrets and with
-  # a token that the called release workflow cannot elevate.
+  # Branch code is validated without repository secrets. The reusable
+  # inspection workflow is read-only and cannot publish or modify GitHub.
   contents: read
 
 jobs:
@@ -44,7 +45,7 @@ jobs:
     if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
     permissions:
       contents: read
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/release-dry-run.yml
     with:
       version: "0.1.19"
       tag: "latest"

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -11,6 +11,8 @@ on:
       - ".github/workflows/post-merge-dry-run.yml"
       - ".github/scripts/draft-cloud-plugin-release-notes.mjs"
       - ".github/scripts/draft-cloud-plugin-release-notes.test.mjs"
+      - ".github/scripts/validate-github-release-inventory.mjs"
+      - ".github/scripts/validate-github-release-inventory.test.mjs"
       - ".github/scripts/validate-release-confirmation.mjs"
       - ".github/scripts/validate-release-confirmation.test.mjs"
       - ".github/scripts/retry.sh"
@@ -21,8 +23,7 @@ on:
       - ".gitignore"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   secrets-preflight:

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -11,6 +11,8 @@ on:
       - ".github/workflows/post-merge-dry-run.yml"
       - ".github/scripts/draft-cloud-plugin-release-notes.mjs"
       - ".github/scripts/draft-cloud-plugin-release-notes.test.mjs"
+      - ".github/scripts/validate-release-confirmation.mjs"
+      - ".github/scripts/validate-release-confirmation.test.mjs"
       - ".github/scripts/retry.sh"
       - "package.json"
       - "scripts/generate-telemetry-credentials.cjs"

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -23,50 +23,65 @@ on:
       - ".gitignore"
 
 permissions:
-  # The reusable release workflow also serves real publishes and declares write
-  # permissions. GitHub does not allow a called workflow to elevate a read-only
-  # caller token, so safety here is enforced by the immutable dry_run=true input.
-  contents: write
-  pull-requests: write
+  # Branch code is intentionally validated without repository secrets and with
+  # a token that the called release workflow cannot elevate.
+  contents: read
 
 jobs:
   secrets-preflight:
     if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Validate dry-run secrets
+      - name: Confirm secretless branch inspection
         shell: bash
-        env:
-          DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
-          DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
-          DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
         run: |
           set -euo pipefail
-          missing=0
-          if [ -z "${DOC_AGENT_RELEASE_NOTES_DRAFT_URL//[[:space:]]/}" ]; then
-            echo "::error::DOC_AGENT_RELEASE_NOTES_DRAFT_URL repository secret is required for evidence-backed dry runs."
-            missing=1
-          fi
-          if [ -z "${DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN//[[:space:]]/}" ]; then
-            echo "::error::DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN repository secret is required for evidence-backed dry runs."
-            missing=1
-          fi
-          if [ -z "${DOC_AGENT_RELEASE_FAILURE_URL//[[:space:]]/}" ]; then
-            echo "::warning::DOC_AGENT_RELEASE_FAILURE_URL is not set; exhausted retry notifications will be skipped."
-          fi
-          if [ "${missing}" -ne 0 ]; then
-            exit 1
-          fi
+          echo "Pre-merge inspection uses a checked-in evidence-backed fixture."
+          echo "No repository secret is passed to branch-controlled workflow code."
 
   dry-run:
     needs: secrets-preflight
     if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/release.yml
     with:
       version: "0.1.19"
       tag: "latest"
       git_ref: ""
-      release_notes: ""
+      release_notes: |
+        ## Changelog
+
+        ### Improved
+        - **系统事件过滤增强**：自动跳过定时任务、计划提醒和后台命令结果，减少记忆污染。
+        - **系统提示识别优化**：兼容单行压缩内容并降低普通消息误判概率。
+
+        <!-- doc-agent-release-notes-json
+        {
+          "schema": "memos.plugin.release_notes.v1",
+          "items": [
+            {
+              "category": "Improved",
+              "text_cn": "**系统事件过滤增强**：自动跳过定时任务、计划提醒和后台命令结果，减少记忆污染。",
+              "text_en": "**System-event filtering**: Skips scheduled tasks, reminders, and background command results to keep memory cleaner.",
+              "source_refs": ["d053b0a"]
+            },
+            {
+              "category": "Improved",
+              "text_cn": "**系统提示识别优化**：兼容单行压缩内容并降低普通消息误判概率。",
+              "text_en": "**System prompt detection**: Supports flattened single-line prompts and reduces false positives on regular messages.",
+              "source_refs": ["d053b0a"]
+            }
+          ],
+          "coverage": {
+            "needs_review": false,
+            "required_count": 1,
+            "covered_required_count": 1,
+            "missing_required_count": 0
+          }
+        }
+        -->
+
+        <!-- doc-agent: source-id=openclaw-cloud-plugin -->
       dry_run: true
       recover_existing_npm_release: false
-    secrets: inherit

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -6,6 +6,7 @@ on:
       - "docs-sync/**"
     paths:
       - ".github/workflows/release.yml"
+      - ".github/workflows/historical-dry-run.yml"
       - ".github/workflows/pre-merge-dry-run.yml"
       - ".github/workflows/post-merge-dry-run.yml"
       - ".github/scripts/draft-cloud-plugin-release-notes.mjs"

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,304 @@
+name: OpenClaw Cloud Plugin — Reusable Release Dry Run
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to inspect (e.g. 0.1.19 or 0.1.20-beta.1)."
+        required: true
+        type: string
+      tag:
+        description: "npm dist-tag paired with the inspected version."
+        required: false
+        type: string
+        default: "latest"
+      git_ref:
+        description: "Git ref containing the workflow and package code. Leave blank to use the caller ref."
+        required: false
+        type: string
+        default: ""
+      release_notes:
+        description: "Optional evidence-backed Markdown. Leave blank to request a Doc Agent draft."
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Compatibility guard. Reusable callers may only pass true."
+        required: false
+        type: boolean
+        default: true
+      recover_existing_npm_release:
+        description: "Compatibility guard. Reusable dry runs may only pass false."
+        required: false
+        type: boolean
+        default: false
+      fault_case:
+        description: "Release-note fault injection used by dry-run validation."
+        required: false
+        type: string
+        default: "none"
+      artifact_name:
+        description: "Inspection artifact name."
+        required: false
+        type: string
+        default: "openclaw-cloud-plugin-release-inspection"
+      expected_previous_tag:
+        description: "Optional assertion for a known historical range."
+        required: false
+        type: string
+        default: ""
+      expected_current_ref:
+        description: "Optional immutable evidence ref; defaults to v<version>."
+        required: false
+        type: string
+        default: ""
+    secrets:
+      DOC_AGENT_RELEASE_NOTES_DRAFT_URL:
+        description: "Doc Agent release-note draft endpoint."
+        required: false
+      DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN:
+        description: "Bearer token for the Doc Agent draft endpoint."
+        required: false
+      DOC_AGENT_RELEASE_FAILURE_URL:
+        description: "Optional exhausted-failure reporting endpoint."
+        required: false
+      MEMOS_ARMS_ENDPOINT:
+        description: "Optional telemetry endpoint injected into the inspection package."
+        required: false
+      MEMOS_ARMS_PID:
+        description: "Optional telemetry project identifier."
+        required: false
+      MEMOS_ARMS_ENV:
+        description: "Optional telemetry environment."
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.git_ref || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Validate immutable dry-run inputs
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          NPM_DIST_TAG: ${{ inputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          RECOVER_EXISTING_NPM_RELEASE: ${{ inputs.recover_existing_npm_release }}
+          RELEASE_FAULT_CASE: ${{ inputs.fault_case }}
+          MANUAL_RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          if [ "${DRY_RUN}" != "true" ]; then
+            echo "::error::The reusable inspection workflow only accepts dry_run=true."
+            exit 1
+          fi
+          if [ "${RECOVER_EXISTING_NPM_RELEASE}" != "false" ]; then
+            echo "::error::The reusable inspection workflow never performs npm recovery."
+            exit 1
+          fi
+          if [[ "${RELEASE_VERSION}" == [vV]* ]]; then
+            echo "::error::version must not include a leading v."
+            exit 1
+          fi
+          if ! [[ "${RELEASE_VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "::error::version must be a valid SemVer value."
+            exit 1
+          fi
+          if ! [[ "${NPM_DIST_TAG}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "::error::tag must be a valid npm dist-tag."
+            exit 1
+          fi
+          if [[ "${RELEASE_VERSION}" == *-* ]] && [ "${NPM_DIST_TAG}" = "latest" ]; then
+            echo "::error::Prerelease versions cannot use the latest npm dist-tag."
+            exit 1
+          fi
+          if [[ "${RELEASE_VERSION}" != *-* ]] && [ "${NPM_DIST_TAG}" != "latest" ]; then
+            echo "::error::Stable versions must use the latest npm dist-tag."
+            exit 1
+          fi
+          if [ "${RELEASE_FAULT_CASE}" = "manual_notes_missing_payload" ] && [ -z "${MANUAL_RELEASE_NOTES}" ]; then
+            echo "::error::manual_notes_missing_payload requires a manual release_notes fixture."
+            exit 1
+          fi
+
+      - name: Resolve immutable evidence ref
+        id: release_source
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          EXPECTED_CURRENT_REF: ${{ inputs.expected_current_ref }}
+        run: |
+          set -euo pipefail
+          evidence_ref="${EXPECTED_CURRENT_REF:-v${RELEASE_VERSION}}"
+          if ! git rev-parse --verify --quiet "${evidence_ref}^{commit}" >/dev/null; then
+            echo "::error::Evidence ref ${evidence_ref} is not an available commit."
+            exit 1
+          fi
+          echo "evidence_ref=${evidence_ref}" >> "${GITHUB_OUTPUT}"
+
+      - name: Install dependencies
+        shell: bash
+        run: bash .github/scripts/retry.sh --label "npm install" -- npm install
+
+      - name: Run tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .github/scripts/retry.sh --attempts 2 --label "release workflow script tests" -- node --test .github/scripts/*.test.mjs
+          if compgen -G "test/*.test.mjs" >/dev/null; then
+            bash .github/scripts/retry.sh --attempts 2 --label "plugin tests" -- node --test test/*.test.mjs
+          else
+            echo "No plugin tests found; skipping."
+          fi
+
+      - name: Bump package and plugin versions
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          bash .github/scripts/retry.sh --label "bump package version" -- npm version "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
+          npm run sync-version
+
+      - name: Generate telemetry credentials
+        shell: bash
+        env:
+          MEMOS_ARMS_ENDPOINT: ${{ secrets.MEMOS_ARMS_ENDPOINT }}
+          MEMOS_ARMS_PID: ${{ secrets.MEMOS_ARMS_PID }}
+          MEMOS_ARMS_ENV: ${{ secrets.MEMOS_ARMS_ENV }}
+        run: bash .github/scripts/retry.sh --label "generate telemetry credentials" -- node scripts/generate-telemetry-credentials.cjs
+
+      - name: Verify synchronized versions and package contents
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const expected = require('./package.json').version;
+          for (const file of ['openclaw.plugin.json', 'moltbot.plugin.json', 'clawdbot.plugin.json']) {
+            const actual = JSON.parse(fs.readFileSync(file, 'utf8')).version;
+            if (actual !== expected) throw new Error(`${file}: expected ${expected}, got ${actual}`);
+          }
+          NODE
+          bash .github/scripts/retry.sh --label "npm pack dry-run" -- bash -euo pipefail -c 'npm pack --dry-run --json > "${RUNNER_TEMP}/openclaw-cloud-plugin-pack.json"'
+
+      - name: Draft and validate GitHub Release notes
+        id: release_notes
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: v${{ inputs.version }}
+          RELEASE_EVIDENCE_REF: ${{ steps.release_source.outputs.evidence_ref }}
+          MANUAL_RELEASE_NOTES: ${{ inputs.release_notes }}
+          RELEASE_FAULT_CASE: ${{ inputs.fault_case }}
+          DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
+          DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
+          DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
+        run: node .github/scripts/draft-cloud-plugin-release-notes.mjs
+
+      - name: Prepare release inspection artifact
+        if: ${{ always() }}
+        shell: bash
+        env:
+          DRAFT_STEP_OUTCOME: ${{ steps.release_notes.outcome }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          FAULT_CASE: ${{ inputs.fault_case }}
+          RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
+          EVIDENCE_FILE: ${{ steps.release_notes.outputs.evidence_file }}
+          DRAFT_FILE: ${{ steps.release_notes.outputs.draft_file }}
+          DOCS_PREVIEW_FILE: ${{ steps.release_notes.outputs.docs_preview_file }}
+          DOCS_PREVIEW_MARKDOWN_FILE: ${{ steps.release_notes.outputs.docs_preview_markdown_file }}
+          QUALITY_REPORT_FILE: ${{ steps.release_notes.outputs.quality_report_file }}
+          DRAFT_USED: ${{ steps.release_notes.outputs.draft_used }}
+          PREVIOUS_TAG: ${{ steps.release_notes.outputs.previous_tag }}
+          CURRENT_REF: ${{ steps.release_notes.outputs.current_ref }}
+          VALIDATION_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.validation_attempt_count }}
+          REPAIR_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.repair_attempt_count }}
+          EXPECTED_PREVIOUS_TAG: ${{ inputs.expected_previous_tag }}
+          EXPECTED_CURRENT_REF: ${{ inputs.expected_current_ref }}
+        run: |
+          set -euo pipefail
+          inspection_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-inspection"
+          mkdir -p "${inspection_dir}"
+
+          copy_if_present() {
+            local source_file="$1"
+            local target_name="$2"
+            if [ -n "${source_file}" ] && [ -s "${source_file}" ]; then
+              cp "${source_file}" "${inspection_dir}/${target_name}"
+            fi
+          }
+          copy_if_present "${RELEASE_NOTES_FILE}" "release-notes.md"
+          copy_if_present "${EVIDENCE_FILE}" "evidence.json"
+          copy_if_present "${DRAFT_FILE}" "release-notes-draft.json"
+          copy_if_present "${DOCS_PREVIEW_FILE}" "docs-preview.json"
+          copy_if_present "${DOCS_PREVIEW_MARKDOWN_FILE}" "docs-preview.md"
+          copy_if_present "${QUALITY_REPORT_FILE}" "quality-report.json"
+          copy_if_present "${RUNNER_TEMP}/openclaw-cloud-plugin-pack.json" "npm-pack.json"
+
+          if [ "${DRAFT_STEP_OUTCOME}" = "success" ] && [ ! -s "${inspection_dir}/release-notes.md" ]; then
+            echo "::error::release-notes.md was not generated."
+            exit 1
+          fi
+          if [ "${DRAFT_STEP_OUTCOME}" = "success" ] && [ ! -s "${inspection_dir}/quality-report.json" ]; then
+            echo "::error::quality-report.json was not generated."
+            exit 1
+          fi
+          if [ "${DRAFT_STEP_OUTCOME}" = "success" ] && [ -n "${EXPECTED_PREVIOUS_TAG}" ] && [ "${PREVIOUS_TAG}" != "${EXPECTED_PREVIOUS_TAG}" ]; then
+            echo "::error::Expected previous_tag=${EXPECTED_PREVIOUS_TAG}, got ${PREVIOUS_TAG:-n/a}."
+            exit 1
+          fi
+          if [ "${DRAFT_STEP_OUTCOME}" = "success" ] && [ -n "${EXPECTED_CURRENT_REF}" ] && [ "${CURRENT_REF}" != "${EXPECTED_CURRENT_REF}" ]; then
+            echo "::error::Expected current_ref=${EXPECTED_CURRENT_REF}, got ${CURRENT_REF:-n/a}."
+            exit 1
+          fi
+
+          {
+            echo "# OpenClaw cloud plugin release inspection"
+            echo
+            echo "- draft_step_outcome: ${DRAFT_STEP_OUTCOME}"
+            echo "- version: ${RELEASE_VERSION}"
+            echo "- fault_case: ${FAULT_CASE}"
+            echo "- draft_used: ${DRAFT_USED:-unknown}"
+            echo "- previous_tag: ${PREVIOUS_TAG:-n/a}"
+            echo "- current_ref: ${CURRENT_REF:-n/a}"
+            echo "- validation_attempt_count: ${VALIDATION_ATTEMPT_COUNT:-n/a}"
+            echo "- repair_attempt_count: ${REPAIR_ATTEMPT_COUNT:-n/a}"
+            echo "- token_permissions: contents:read"
+            echo "- repository_credentials_persisted: false"
+          } > "${inspection_dir}/README.md"
+
+          {
+            echo "### OpenClaw cloud plugin release dry run"
+            echo
+            echo "- outcome: \`${DRAFT_STEP_OUTCOME}\`"
+            echo "- version: \`${RELEASE_VERSION}\`"
+            echo "- previous_tag: \`${PREVIOUS_TAG:-n/a}\`"
+            echo "- current_ref: \`${CURRENT_REF:-n/a}\`"
+            echo "- validation_attempt_count: \`${VALIDATION_ATTEMPT_COUNT:-n/a}\`"
+            echo "- repair_attempt_count: \`${REPAIR_ATTEMPT_COUNT:-n/a}\`"
+            echo "- permissions: \`contents: read\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload release inspection artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ runner.temp }}/openclaw-cloud-plugin-release-inspection
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,6 +329,7 @@ jobs:
         if: ${{ inputs.dry_run != true }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PACKAGE_NAME: "@memtensor/memos-cloud-openclaw-plugin"
           RELEASE_VERSION: ${{ inputs.version }}
           RELEASE_TAG: v${{ inputs.version }}
@@ -380,15 +381,54 @@ jobs:
               sleep "$((attempt * 5))"
             done
           }
+          github_release_exists() {
+            local release_tag="$1"
+            local out="${RUNNER_TEMP}/openclaw-cloud-plugin-release-view.log"
+            for attempt in 1 2 3; do
+              set +e
+              gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >"${out}" 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                return 0
+              fi
+              if grep -Eiq "not found|could not find|HTTP 404" "${out}"; then
+                return 1
+              fi
+              sed -n '1,120p' "${out}"
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to check GitHub Release ${release_tag} after three attempts."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
 
           if npm_version_exists; then
             release_tag="v${RELEASE_VERSION}"
+            tag_exists=false
+            release_exists=false
             if remote_tag_exists "${release_tag}"; then
-              echo "${PACKAGE_NAME}@${RELEASE_VERSION} and ${release_tag} already exist; treating this as an idempotent rerun."
+              tag_exists=true
+            fi
+            if github_release_exists "${release_tag}"; then
+              release_exists=true
+            fi
+            if [ "${tag_exists}" = "true" ] && [ "${release_exists}" = "true" ]; then
+              echo "${PACKAGE_NAME}@${RELEASE_VERSION}, ${release_tag}, and the GitHub Release already exist; treating this as an idempotent rerun."
             elif [ "${RECOVER_EXISTING_NPM_RELEASE}" = "true" ]; then
-              echo "Recovery mode enabled; npm version exists, so publish is skipped."
+              echo "Recovery mode enabled; npm version exists, so publish is skipped and missing GitHub metadata may be reconstructed."
             else
-              echo "::error::npm version exists but ${release_tag} does not. Refusing to invent release metadata without explicit recovery mode."
+              missing=()
+              if [ "${tag_exists}" != "true" ]; then
+                missing+=("${release_tag}")
+              fi
+              if [ "${release_exists}" != "true" ]; then
+                missing+=("GitHub Release ${release_tag}")
+              fi
+              printf -v missing_text "%s, " "${missing[@]}"
+              missing_text="${missing_text%, }"
+              echo "::error::${PACKAGE_NAME}@${RELEASE_VERSION} already exists on npm, but ${missing_text} is missing. Set recover_existing_npm_release=true only for an intentional metadata backfill."
               exit 1
             fi
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,84 +46,6 @@ on:
           - thirteen_items
           - too_long
           - manual_notes_missing_payload
-  workflow_call:
-    inputs:
-      version:
-        description: "Version to publish or dry-run (e.g. 0.1.19 or 0.1.20-beta.1)"
-        required: true
-        type: string
-      tag:
-        description: "npm dist-tag (latest for production, beta/next/alpha for testing)"
-        required: false
-        type: string
-        default: "latest"
-      git_ref:
-        description: "Git ref to build from. Leave blank to use the caller ref."
-        required: false
-        type: string
-        default: ""
-      release_notes:
-        description: "Optional evidence-backed Markdown. Leave blank to draft it from git evidence."
-        required: false
-        type: string
-        default: ""
-      dry_run:
-        description: "Build, validate, and generate inspection artifacts without publishing or changing GitHub."
-        required: false
-        type: boolean
-        default: true
-      publish_confirmation:
-        description: "Required only when dry_run=false. Must exactly equal: PUBLISH v<version>"
-        required: false
-        type: string
-        default: ""
-      recover_existing_npm_release:
-        description: "Backfill a missing tag/Release from npm gitHead without republishing. Keep false for normal releases."
-        required: false
-        type: boolean
-        default: false
-      fault_case:
-        description: "Dry-run-only release-note fault injection."
-        required: false
-        type: string
-        default: "none"
-      artifact_name:
-        description: "Inspection artifact name. Intended for reusable dry-run matrix callers."
-        required: false
-        type: string
-        default: "openclaw-cloud-plugin-release-inspection"
-      expected_previous_tag:
-        description: "Optional assertion for dry-run callers that validate a known historical range."
-        required: false
-        type: string
-        default: ""
-      expected_current_ref:
-        description: "Optional assertion for dry-run callers that validate a known historical evidence ref."
-        required: false
-        type: string
-        default: ""
-    secrets:
-      DOC_AGENT_RELEASE_NOTES_DRAFT_URL:
-        description: "Doc Agent release-note draft endpoint."
-        required: false
-      DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN:
-        description: "Bearer token for the Doc Agent draft endpoint."
-        required: false
-      DOC_AGENT_RELEASE_FAILURE_URL:
-        description: "Optional exhausted-failure reporting endpoint."
-        required: false
-      MEMOS_ARMS_ENDPOINT:
-        description: "Optional telemetry endpoint injected into the package."
-        required: false
-      MEMOS_ARMS_PID:
-        description: "Optional telemetry project identifier."
-        required: false
-      MEMOS_ARMS_ENV:
-        description: "Optional telemetry environment."
-        required: false
-      NPM_TOKEN:
-        description: "npm publish token. Never pass this to reusable dry-run callers."
-        required: false
 
 concurrency:
   group: openclaw-cloud-plugin-publish
@@ -142,6 +64,7 @@ jobs:
         with:
           ref: ${{ inputs.git_ref || github.ref }}
           fetch-depth: 0
+          persist-credentials: ${{ inputs.dry_run != true }}
 
       - uses: actions/setup-node@v7
         with:
@@ -378,8 +301,8 @@ jobs:
           MISSING_REQUIRED_COUNT: ${{ steps.release_notes.outputs.missing_required_count }}
           VALIDATION_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.validation_attempt_count }}
           REPAIR_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.repair_attempt_count }}
-          EXPECTED_PREVIOUS_TAG: ${{ inputs.expected_previous_tag }}
-          EXPECTED_CURRENT_REF: ${{ inputs.expected_current_ref }}
+          EXPECTED_PREVIOUS_TAG: ""
+          EXPECTED_CURRENT_REF: ""
         run: |
           set -euo pipefail
           inspection_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-inspection"
@@ -492,7 +415,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ inputs.artifact_name || 'openclaw-cloud-plugin-release-inspection' }}
+          name: openclaw-cloud-plugin-release-inspection
           path: ${{ runner.temp }}/openclaw-cloud-plugin-release-inspection
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,9 @@ on:
       MEMOS_ARMS_ENV:
         description: "Optional telemetry environment."
         required: false
+      NPM_TOKEN:
+        description: "npm publish token. Never pass this to reusable dry-run callers."
+        required: false
 
 concurrency:
   group: openclaw-cloud-plugin-publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,25 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      DOC_AGENT_RELEASE_NOTES_DRAFT_URL:
+        description: "Doc Agent release-note draft endpoint."
+        required: false
+      DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN:
+        description: "Bearer token for the Doc Agent draft endpoint."
+        required: false
+      DOC_AGENT_RELEASE_FAILURE_URL:
+        description: "Optional exhausted-failure reporting endpoint."
+        required: false
+      MEMOS_ARMS_ENDPOINT:
+        description: "Optional telemetry endpoint injected into the package."
+        required: false
+      MEMOS_ARMS_PID:
+        description: "Optional telemetry project identifier."
+        required: false
+      MEMOS_ARMS_ENV:
+        description: "Optional telemetry environment."
+        required: false
 
 concurrency:
   group: openclaw-cloud-plugin-publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,21 @@ on:
         required: false
         type: boolean
         default: false
+      artifact_name:
+        description: "Inspection artifact name. Intended for reusable dry-run matrix callers."
+        required: false
+        type: string
+        default: "openclaw-cloud-plugin-release-inspection"
+      expected_previous_tag:
+        description: "Optional assertion for dry-run callers that validate a known historical range."
+        required: false
+        type: string
+        default: ""
+      expected_current_ref:
+        description: "Optional assertion for dry-run callers that validate a known historical evidence ref."
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: openclaw-cloud-plugin-publish
@@ -172,6 +187,8 @@ jobs:
           RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
           EVIDENCE_FILE: ${{ steps.release_notes.outputs.evidence_file }}
           DRAFT_FILE: ${{ steps.release_notes.outputs.draft_file }}
+          DOCS_PREVIEW_FILE: ${{ steps.release_notes.outputs.docs_preview_file }}
+          DOCS_PREVIEW_MARKDOWN_FILE: ${{ steps.release_notes.outputs.docs_preview_markdown_file }}
           DRAFT_USED: ${{ steps.release_notes.outputs.draft_used }}
           PREVIOUS_TAG: ${{ steps.release_notes.outputs.previous_tag }}
           CURRENT_TAG: ${{ steps.release_notes.outputs.current_tag }}
@@ -180,6 +197,8 @@ jobs:
           MISSING_REQUIRED_COUNT: ${{ steps.release_notes.outputs.missing_required_count }}
           VALIDATION_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.validation_attempt_count }}
           REPAIR_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.repair_attempt_count }}
+          EXPECTED_PREVIOUS_TAG: ${{ inputs.expected_previous_tag }}
+          EXPECTED_CURRENT_REF: ${{ inputs.expected_current_ref }}
         run: |
           set -euo pipefail
           inspection_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-inspection"
@@ -187,6 +206,15 @@ jobs:
 
           if [ -z "${RELEASE_NOTES_FILE}" ] || [ ! -s "${RELEASE_NOTES_FILE}" ]; then
             echo "::error::Release notes file was not generated."
+            exit 1
+          fi
+
+          if [ -n "${EXPECTED_PREVIOUS_TAG:-}" ] && [ "${PREVIOUS_TAG:-}" != "${EXPECTED_PREVIOUS_TAG}" ]; then
+            echo "::error::Expected previous_tag=${EXPECTED_PREVIOUS_TAG}, got ${PREVIOUS_TAG:-n/a}."
+            exit 1
+          fi
+          if [ -n "${EXPECTED_CURRENT_REF:-}" ] && [ "${CURRENT_REF:-}" != "${EXPECTED_CURRENT_REF}" ]; then
+            echo "::error::Expected current_ref=${EXPECTED_CURRENT_REF}, got ${CURRENT_REF:-n/a}."
             exit 1
           fi
 
@@ -201,8 +229,24 @@ jobs:
               exit 1
             fi
             cp "${DRAFT_FILE}" "${inspection_dir}/release-notes-draft.json"
+            if [ -z "${DOCS_PREVIEW_FILE}" ] || [ ! -s "${DOCS_PREVIEW_FILE}" ]; then
+              echo "::error::Docs preview JSON file was not generated."
+              exit 1
+            fi
+            if [ -z "${DOCS_PREVIEW_MARKDOWN_FILE}" ] || [ ! -s "${DOCS_PREVIEW_MARKDOWN_FILE}" ]; then
+              echo "::error::Docs preview Markdown file was not generated."
+              exit 1
+            fi
+            cp "${DOCS_PREVIEW_FILE}" "${inspection_dir}/docs-preview.json"
+            cp "${DOCS_PREVIEW_MARKDOWN_FILE}" "${inspection_dir}/docs-preview.md"
           elif [ -n "${DRAFT_FILE}" ] && [ -s "${DRAFT_FILE}" ]; then
             cp "${DRAFT_FILE}" "${inspection_dir}/release-notes-draft.json"
+            if [ -n "${DOCS_PREVIEW_FILE}" ] && [ -s "${DOCS_PREVIEW_FILE}" ]; then
+              cp "${DOCS_PREVIEW_FILE}" "${inspection_dir}/docs-preview.json"
+            fi
+            if [ -n "${DOCS_PREVIEW_MARKDOWN_FILE}" ] && [ -s "${DOCS_PREVIEW_MARKDOWN_FILE}" ]; then
+              cp "${DOCS_PREVIEW_MARKDOWN_FILE}" "${inspection_dir}/docs-preview.md"
+            fi
           fi
 
           {
@@ -229,6 +273,10 @@ jobs:
             if [ -f "${inspection_dir}/release-notes-draft.json" ]; then
               echo "- release-notes-draft.json"
             fi
+            if [ -f "${inspection_dir}/docs-preview.md" ]; then
+              echo "- docs-preview.md"
+              echo "- docs-preview.json"
+            fi
           } > "${inspection_dir}/README.md"
 
           {
@@ -245,12 +293,18 @@ jobs:
             echo "- repair_attempt_count: \`${REPAIR_ATTEMPT_COUNT:-n/a}\`"
             echo
             echo "Download the workflow artifact \`openclaw-cloud-plugin-release-inspection\` to review release-notes.md, release-notes-draft.json, and redacted evidence.json."
+            if [ -f "${inspection_dir}/docs-preview.md" ]; then
+              echo
+              echo "### MemOS-Docs preview"
+              echo
+              sed -n '1,120p' "${inspection_dir}/docs-preview.md"
+            fi
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload release inspection artifact
         uses: actions/upload-artifact@v4
         with:
-          name: openclaw-cloud-plugin-release-inspection
+          name: ${{ inputs.artifact_name || 'openclaw-cloud-plugin-release-inspection' }}
           path: ${{ runner.temp }}/openclaw-cloud-plugin-release-inspection
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ on:
         required: true
         type: boolean
         default: true
+      publish_confirmation:
+        description: "Required only when dry_run=false. Must exactly equal: PUBLISH v<version>"
+        required: false
+        default: ""
       recover_existing_npm_release:
         description: "Explicitly allow reconstructing GitHub metadata for a version already on npm. Keep false for normal releases."
         required: true
@@ -54,6 +58,11 @@ on:
         required: false
         type: boolean
         default: true
+      publish_confirmation:
+        description: "Required only when dry_run=false. Must exactly equal: PUBLISH v<version>"
+        required: false
+        type: string
+        default: ""
       recover_existing_npm_release:
         description: "Allow reconstructing a missing tag/Release for an npm version. Keep false for normal releases."
         required: false
@@ -103,6 +112,8 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.version }}
           NPM_DIST_TAG: ${{ inputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          PUBLISH_CONFIRMATION: ${{ inputs.publish_confirmation }}
         run: |
           set -euo pipefail
           if [[ "${RELEASE_VERSION}" == [vV]* ]]; then
@@ -121,6 +132,7 @@ jobs:
             echo "::error::tag must be a valid npm dist-tag."
             exit 1
           fi
+          node .github/scripts/validate-release-confirmation.mjs
 
       - name: Install dependencies
         shell: bash
@@ -130,7 +142,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bash .github/scripts/retry.sh --attempts 2 --label "release notes tests" -- node --test .github/scripts/draft-cloud-plugin-release-notes.test.mjs
+          bash .github/scripts/retry.sh --attempts 2 --label "release workflow script tests" -- node --test .github/scripts/*.test.mjs
           if compgen -G "test/*.test.mjs" >/dev/null; then
             bash .github/scripts/retry.sh --attempts 2 --label "plugin tests" -- node --test test/*.test.mjs
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,20 @@ on:
         required: true
         type: boolean
         default: false
+      fault_case:
+        description: "Dry-run-only release-note fault injection."
+        required: true
+        type: choice
+        default: "none"
+        options:
+          - none
+          - mixed_language
+          - missing_source_refs
+          - missing_important_commit
+          - invalid_source_ref
+          - thirteen_items
+          - too_long
+          - manual_notes_missing_payload
   workflow_call:
     inputs:
       version:
@@ -68,6 +82,11 @@ on:
         required: false
         type: boolean
         default: false
+      fault_case:
+        description: "Dry-run-only release-note fault injection."
+        required: false
+        type: string
+        default: "none"
       artifact_name:
         description: "Inspection artifact name. Intended for reusable dry-run matrix callers."
         required: false
@@ -97,12 +116,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.git_ref || github.ref }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -114,6 +133,7 @@ jobs:
           NPM_DIST_TAG: ${{ inputs.tag }}
           DRY_RUN: ${{ inputs.dry_run }}
           PUBLISH_CONFIRMATION: ${{ inputs.publish_confirmation }}
+          RELEASE_FAULT_CASE: ${{ inputs.fault_case }}
         run: |
           set -euo pipefail
           if [[ "${RELEASE_VERSION}" == [vV]* ]]; then
@@ -130,6 +150,10 @@ jobs:
           fi
           if ! [[ "${NPM_DIST_TAG}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
             echo "::error::tag must be a valid npm dist-tag."
+            exit 1
+          fi
+          if [ "${DRY_RUN}" != "true" ] && [ "${RELEASE_FAULT_CASE}" != "none" ]; then
+            echo "::error::fault_case is only allowed when dry_run=true."
             exit 1
           fi
           node .github/scripts/validate-release-confirmation.mjs
@@ -186,21 +210,26 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
           RELEASE_TAG: v${{ inputs.version }}
           MANUAL_RELEASE_NOTES: ${{ inputs.release_notes }}
+          RELEASE_FAULT_CASE: ${{ inputs.fault_case }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
           DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
-        run: bash .github/scripts/retry.sh --attempts 2 --label "draft GitHub Release notes" -- node .github/scripts/draft-cloud-plugin-release-notes.mjs
+        run: node .github/scripts/draft-cloud-plugin-release-notes.mjs
 
       - name: Prepare release inspection artifact
+        if: ${{ always() }}
         shell: bash
         env:
+          DRAFT_STEP_OUTCOME: ${{ steps.release_notes.outcome }}
           DRY_RUN: ${{ inputs.dry_run }}
           RELEASE_VERSION: ${{ inputs.version }}
+          FAULT_CASE: ${{ inputs.fault_case }}
           RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
           EVIDENCE_FILE: ${{ steps.release_notes.outputs.evidence_file }}
           DRAFT_FILE: ${{ steps.release_notes.outputs.draft_file }}
           DOCS_PREVIEW_FILE: ${{ steps.release_notes.outputs.docs_preview_file }}
           DOCS_PREVIEW_MARKDOWN_FILE: ${{ steps.release_notes.outputs.docs_preview_markdown_file }}
+          QUALITY_REPORT_FILE: ${{ steps.release_notes.outputs.quality_report_file }}
           DRAFT_USED: ${{ steps.release_notes.outputs.draft_used }}
           PREVIOUS_TAG: ${{ steps.release_notes.outputs.previous_tag }}
           CURRENT_TAG: ${{ steps.release_notes.outputs.current_tag }}
@@ -216,56 +245,53 @@ jobs:
           inspection_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-inspection"
           mkdir -p "${inspection_dir}"
 
-          if [ -z "${RELEASE_NOTES_FILE}" ] || [ ! -s "${RELEASE_NOTES_FILE}" ]; then
+          if [ "${DRAFT_STEP_OUTCOME}" = "success" ] && { [ -z "${RELEASE_NOTES_FILE}" ] || [ ! -s "${RELEASE_NOTES_FILE}" ]; }; then
             echo "::error::Release notes file was not generated."
             exit 1
           fi
 
-          if [ -n "${EXPECTED_PREVIOUS_TAG:-}" ] && [ "${PREVIOUS_TAG:-}" != "${EXPECTED_PREVIOUS_TAG}" ]; then
+          if [ "${DRAFT_STEP_OUTCOME}" = "success" ] && [ -n "${EXPECTED_PREVIOUS_TAG:-}" ] && [ "${PREVIOUS_TAG:-}" != "${EXPECTED_PREVIOUS_TAG}" ]; then
             echo "::error::Expected previous_tag=${EXPECTED_PREVIOUS_TAG}, got ${PREVIOUS_TAG:-n/a}."
             exit 1
           fi
-          if [ -n "${EXPECTED_CURRENT_REF:-}" ] && [ "${CURRENT_REF:-}" != "${EXPECTED_CURRENT_REF}" ]; then
+          if [ "${DRAFT_STEP_OUTCOME}" = "success" ] && [ -n "${EXPECTED_CURRENT_REF:-}" ] && [ "${CURRENT_REF:-}" != "${EXPECTED_CURRENT_REF}" ]; then
             echo "::error::Expected current_ref=${EXPECTED_CURRENT_REF}, got ${CURRENT_REF:-n/a}."
             exit 1
           fi
 
-          cp "${RELEASE_NOTES_FILE}" "${inspection_dir}/release-notes.md"
-          cp "${RUNNER_TEMP}/openclaw-cloud-plugin-pack.json" "${inspection_dir}/npm-pack.json"
+          if [ -n "${RELEASE_NOTES_FILE}" ] && [ -s "${RELEASE_NOTES_FILE}" ]; then
+            cp "${RELEASE_NOTES_FILE}" "${inspection_dir}/release-notes.md"
+          fi
+          if [ -s "${RUNNER_TEMP}/openclaw-cloud-plugin-pack.json" ]; then
+            cp "${RUNNER_TEMP}/openclaw-cloud-plugin-pack.json" "${inspection_dir}/npm-pack.json"
+          fi
           if [ -n "${EVIDENCE_FILE}" ] && [ -s "${EVIDENCE_FILE}" ]; then
             cp "${EVIDENCE_FILE}" "${inspection_dir}/evidence.json"
           fi
-          if [ "${DRAFT_USED:-}" = "true" ]; then
-            if [ -z "${DRAFT_FILE}" ] || [ ! -s "${DRAFT_FILE}" ]; then
-              echo "::error::Draft JSON file was not generated."
-              exit 1
-            fi
+          if [ -n "${DRAFT_FILE}" ] && [ -s "${DRAFT_FILE}" ]; then
             cp "${DRAFT_FILE}" "${inspection_dir}/release-notes-draft.json"
-            if [ -z "${DOCS_PREVIEW_FILE}" ] || [ ! -s "${DOCS_PREVIEW_FILE}" ]; then
-              echo "::error::Docs preview JSON file was not generated."
-              exit 1
-            fi
-            if [ -z "${DOCS_PREVIEW_MARKDOWN_FILE}" ] || [ ! -s "${DOCS_PREVIEW_MARKDOWN_FILE}" ]; then
-              echo "::error::Docs preview Markdown file was not generated."
-              exit 1
-            fi
+          fi
+          if [ -n "${DOCS_PREVIEW_FILE}" ] && [ -s "${DOCS_PREVIEW_FILE}" ]; then
             cp "${DOCS_PREVIEW_FILE}" "${inspection_dir}/docs-preview.json"
+          fi
+          if [ -n "${DOCS_PREVIEW_MARKDOWN_FILE}" ] && [ -s "${DOCS_PREVIEW_MARKDOWN_FILE}" ]; then
             cp "${DOCS_PREVIEW_MARKDOWN_FILE}" "${inspection_dir}/docs-preview.md"
-          elif [ -n "${DRAFT_FILE}" ] && [ -s "${DRAFT_FILE}" ]; then
-            cp "${DRAFT_FILE}" "${inspection_dir}/release-notes-draft.json"
-            if [ -n "${DOCS_PREVIEW_FILE}" ] && [ -s "${DOCS_PREVIEW_FILE}" ]; then
-              cp "${DOCS_PREVIEW_FILE}" "${inspection_dir}/docs-preview.json"
-            fi
-            if [ -n "${DOCS_PREVIEW_MARKDOWN_FILE}" ] && [ -s "${DOCS_PREVIEW_MARKDOWN_FILE}" ]; then
-              cp "${DOCS_PREVIEW_MARKDOWN_FILE}" "${inspection_dir}/docs-preview.md"
-            fi
+          fi
+          if [ -n "${QUALITY_REPORT_FILE}" ] && [ -s "${QUALITY_REPORT_FILE}" ]; then
+            cp "${QUALITY_REPORT_FILE}" "${inspection_dir}/quality-report.json"
+          fi
+          if [ "${DRAFT_STEP_OUTCOME}" = "success" ] && [ ! -s "${inspection_dir}/quality-report.json" ]; then
+            echo "::error::quality-report.json was not generated."
+            exit 1
           fi
 
           {
             echo "# OpenClaw cloud plugin release inspection"
             echo
+            echo "- draft_step_outcome: ${DRAFT_STEP_OUTCOME}"
             echo "- dry_run: ${DRY_RUN}"
             echo "- version: ${RELEASE_VERSION}"
+            echo "- fault_case: ${FAULT_CASE}"
             echo "- draft_used: ${DRAFT_USED:-unknown}"
             echo "- previous_tag: ${PREVIOUS_TAG:-n/a}"
             echo "- current_tag: ${CURRENT_TAG:-n/a}"
@@ -277,9 +303,13 @@ jobs:
             echo
             echo "Files:"
             echo
-            echo "- release-notes.md"
-            echo "- npm-pack.json"
-            if [ -n "${EVIDENCE_FILE}" ] && [ -s "${EVIDENCE_FILE}" ]; then
+            if [ -f "${inspection_dir}/release-notes.md" ]; then
+              echo "- release-notes.md"
+            fi
+            if [ -f "${inspection_dir}/npm-pack.json" ]; then
+              echo "- npm-pack.json"
+            fi
+            if [ -f "${inspection_dir}/evidence.json" ]; then
               echo "- evidence.json (redacted; no full diff or prompt guidance)"
             fi
             if [ -f "${inspection_dir}/release-notes-draft.json" ]; then
@@ -289,12 +319,17 @@ jobs:
               echo "- docs-preview.md"
               echo "- docs-preview.json"
             fi
+            if [ -f "${inspection_dir}/quality-report.json" ]; then
+              echo "- quality-report.json"
+            fi
           } > "${inspection_dir}/README.md"
 
           {
             echo "### OpenClaw cloud plugin release notes"
             echo
+            echo "- draft_step_outcome: \`${DRAFT_STEP_OUTCOME}\`"
             echo "- dry_run: \`${DRY_RUN}\`"
+            echo "- fault_case: \`${FAULT_CASE}\`"
             echo "- draft_used: \`${DRAFT_USED:-unknown}\`"
             echo "- previous_tag: \`${PREVIOUS_TAG:-n/a}\`"
             echo "- current_tag: \`${CURRENT_TAG:-n/a}\`"
@@ -304,7 +339,7 @@ jobs:
             echo "- validation_attempt_count: \`${VALIDATION_ATTEMPT_COUNT:-n/a}\`"
             echo "- repair_attempt_count: \`${REPAIR_ATTEMPT_COUNT:-n/a}\`"
             echo
-            echo "Download the workflow artifact \`openclaw-cloud-plugin-release-inspection\` to review release-notes.md, release-notes-draft.json, and redacted evidence.json."
+            echo "Download the workflow artifact \`openclaw-cloud-plugin-release-inspection\` to review release-notes.md, quality-report.json, release-notes-draft.json, and redacted evidence.json."
             if [ -f "${inspection_dir}/docs-preview.md" ]; then
               echo
               echo "### MemOS-Docs preview"
@@ -314,7 +349,8 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload release inspection artifact
-        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact_name || 'openclaw-cloud-plugin-release-inspection' }}
           path: ${{ runner.temp }}/openclaw-cloud-plugin-release-inspection

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,6 +503,14 @@ jobs:
           if [[ "${RELEASE_VERSION}" == *-* || "${NPM_DIST_TAG}" != "latest" ]]; then
             expected_release_prerelease=true
           fi
+          report_exhausted_failure() {
+            local phase="$1"
+            local attempt_dir="$2"
+            RELEASE_FAILURE_PHASE="${phase}" \
+              RELEASE_FAILURE_ATTEMPT_DIR="${attempt_dir}" \
+              node .github/scripts/draft-cloud-plugin-release-notes.mjs \
+              || echo "::warning::Failed to report exhausted ${phase} attempts."
+          }
 
           npm_view_log="${RUNNER_TEMP}/openclaw-cloud-plugin-npm-view.log"
           npm_version_exists() {
@@ -738,8 +746,13 @@ jobs:
               fi
               release_commit_sha="$(git rev-parse HEAD)"
               validate_release_commit_versions "${release_commit_sha}"
-              bash .github/scripts/retry.sh --label "push durable release branch" -- \
-                git push origin "${release_commit_sha}:refs/heads/${release_branch}"
+              durable_branch_attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-durable-branch-attempts"
+              if ! RETRY_ATTEMPT_DIR="${durable_branch_attempt_dir}" \
+                bash .github/scripts/retry.sh --label "push durable release branch" -- \
+                  git push origin "${release_commit_sha}:refs/heads/${release_branch}"; then
+                report_exhausted_failure "github-durable-release-branch-push" "${durable_branch_attempt_dir}"
+                exit 1
+              fi
             fi
             create_version_pr=true
 
@@ -778,10 +791,7 @@ jobs:
                 break
               fi
               if [ "${attempt}" = 3 ]; then
-                RELEASE_FAILURE_PHASE=npm-publish \
-                  RELEASE_FAILURE_ATTEMPT_DIR="${attempt_dir}" \
-                  node .github/scripts/draft-cloud-plugin-release-notes.mjs \
-                  || echo "::warning::Failed to send the exhausted-retry notification."
+                report_exhausted_failure "npm-publish" "${attempt_dir}"
                 echo "::error::npm publish failed after three attempts."
                 exit 1
               fi
@@ -813,6 +823,8 @@ jobs:
           RELEASE_COMMIT_SHA: ${{ steps.publish_npm.outputs.release_commit_sha }}
           CREATE_VERSION_PR: ${{ steps.publish_npm.outputs.create_version_pr }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
+          DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "${RELEASE_NOTES_FILE}" ] || [ ! -s "${RELEASE_NOTES_FILE}" ]; then
@@ -838,20 +850,31 @@ jobs:
           if [[ "${RELEASE_VERSION}" == *-* || "${NPM_DIST_TAG}" != "latest" ]]; then
             expected_release_prerelease=true
           fi
+          report_exhausted_failure() {
+            local phase="$1"
+            local attempt_dir="$2"
+            RELEASE_FAILURE_PHASE="${phase}" \
+              RELEASE_FAILURE_ATTEMPT_DIR="${attempt_dir}" \
+              RELEASE_TAG="${release_tag}" \
+              node .github/scripts/draft-cloud-plugin-release-notes.mjs \
+              || echo "::warning::Failed to report exhausted ${phase} attempts."
+          }
           remote_branch_sha() {
             local branch="$1"
-            local out="${RUNNER_TEMP}/openclaw-cloud-plugin-remote-branch.txt"
+            local attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-remote-branch-attempts"
+            mkdir -p "${attempt_dir}"
             for attempt in 1 2 3; do
               set +e
-              git ls-remote --heads origin "${branch}" >"${out}" 2>&1
+              git ls-remote --heads origin "${branch}" >"${attempt_dir}/${attempt}.log" 2>&1
               status=$?
               set -e
               if [ "${status}" = 0 ]; then
-                awk '{print $1}' "${out}"
+                awk '{print $1}' "${attempt_dir}/${attempt}.log"
                 return 0
               fi
-              sed -n '1,120p' "${out}"
+              sed -n '1,120p' "${attempt_dir}/${attempt}.log" >&2
               if [ "${attempt}" = 3 ]; then
+                report_exhausted_failure "github-release-branch-lookup" "${attempt_dir}"
                 echo "::error::Failed to check remote branch ${branch} after three attempts."
                 exit "${status}"
               fi
@@ -860,9 +883,11 @@ jobs:
           }
           remote_tag_exists() {
             local tag="$1"
+            local attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-remote-tag-attempts"
+            mkdir -p "${attempt_dir}"
             for attempt in 1 2 3; do
               set +e
-              git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1
+              git ls-remote --exit-code --tags origin "refs/tags/${tag}" >"${attempt_dir}/${attempt}.log" 2>&1
               status=$?
               set -e
               if [ "${status}" = 0 ]; then
@@ -872,6 +897,7 @@ jobs:
                 return 1
               fi
               if [ "${attempt}" = 3 ]; then
+                report_exhausted_failure "github-release-tag-lookup" "${attempt_dir}"
                 echo "::error::Failed to check remote tag ${tag} after three attempts."
                 exit "${status}"
               fi
@@ -881,19 +907,21 @@ jobs:
           release_inventory_file="${RUNNER_TEMP}/openclaw-cloud-plugin-release-inventory.json"
           refresh_release_inventory() {
             local out="${release_inventory_file}.tmp"
-            local err="${release_inventory_file}.err"
+            local attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-inventory-attempts"
+            mkdir -p "${attempt_dir}"
             for attempt in 1 2 3; do
               set +e
               gh api --paginate --slurp \
-                "repos/${GITHUB_REPOSITORY}/releases?per_page=100" >"${out}" 2>"${err}"
+                "repos/${GITHUB_REPOSITORY}/releases?per_page=100" >"${out}" 2>"${attempt_dir}/${attempt}.log"
               status=$?
               set -e
               if [ "${status}" = 0 ]; then
                 mv "${out}" "${release_inventory_file}"
                 return 0
               fi
-              sed -n '1,120p' "${err}" >&2
+              sed -n '1,120p' "${attempt_dir}/${attempt}.log" >&2
               if [ "${attempt}" = 3 ]; then
+                report_exhausted_failure "github-release-inventory" "${attempt_dir}"
                 echo "::error::Failed to enumerate GitHub Releases after three attempts."
                 exit "${status}"
               fi
@@ -913,6 +941,9 @@ jobs:
           }
           create_release_if_missing() {
             local release_flags=()
+            local create_attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-create-attempts"
+            local verification_attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-verification-attempts"
+            mkdir -p "${create_attempt_dir}" "${verification_attempt_dir}"
             if [ "${expected_release_prerelease}" = "true" ]; then
               release_flags+=(--prerelease)
               echo "Marking GitHub Release ${release_tag} as prerelease because version=${RELEASE_VERSION}, npm_dist_tag=${NPM_DIST_TAG}."
@@ -944,9 +975,10 @@ jobs:
                 --target "${RELEASE_COMMIT_SHA}" \
                 --title "OpenClaw Cloud Plugin ${release_tag}" \
                 --notes-file "${RELEASE_NOTES_FILE}" \
-                "${release_flags[@]}"
+                "${release_flags[@]}" >"${create_attempt_dir}/${attempt}.log" 2>&1
               create_status=$?
               set -e
+              sed -n '1,160p' "${create_attempt_dir}/${attempt}.log"
               echo "::endgroup::"
 
               release_verified=false
@@ -956,6 +988,7 @@ jobs:
                 release_inventory_report="$(inspect_release_inventory true)"
                 release_inventory_status=$?
                 set -e
+                printf '%s\n' "${release_inventory_report}" >"${verification_attempt_dir}/${poll_attempt}.log"
                 release_inventory_state="$(
                   printf '%s' "${release_inventory_report}" |
                     jq -r '.state // "invalid"'
@@ -980,6 +1013,7 @@ jobs:
                 return 0
               fi
               if [ "${create_status}" -eq 0 ]; then
+                report_exhausted_failure "github-release-verification" "${verification_attempt_dir}"
                 echo "::error::GitHub reported a successful Release create, but ${release_tag} could not be verified. Refusing to issue a second create request."
                 exit 1
               fi
@@ -988,10 +1022,13 @@ jobs:
               fi
             done
 
+            report_exhausted_failure "github-release-create" "${create_attempt_dir}"
             echo "::error::Failed to create and verify GitHub Release ${release_tag} after three attempts."
             exit 1
           }
           create_pr_if_missing() {
+            local attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-pr-attempts"
+            mkdir -p "${attempt_dir}"
             if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
               echo "Release PR already exists for ${release_branch}."
               return 0
@@ -1003,19 +1040,23 @@ jobs:
                 --base "${DEFAULT_BRANCH}" \
                 --head "${release_branch}" \
                 --title "${release_title}" \
-                --body "Bumps package.json and plugin manifests for the published npm release ${release_tag}."
+                --body "Bumps package.json and plugin manifests for the published npm release ${release_tag}." \
+                >"${attempt_dir}/${attempt}.log" 2>&1
               status=$?
               set -e
               if [ "${status}" = 0 ]; then
+                sed -n '1,80p' "${attempt_dir}/${attempt}.log"
                 return 0
               fi
+              sed -n '1,120p' "${attempt_dir}/${attempt}.log" >&2
               if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
                 echo "Release PR exists after a failed create response; treating as success."
                 return 0
               fi
               if [ "${attempt}" = 3 ]; then
-                echo "::warning::Failed to create release PR automatically after three attempts. Open a PR from ${release_branch} to ${DEFAULT_BRANCH}."
-                return 0
+                report_exhausted_failure "github-release-pr-create" "${attempt_dir}"
+                echo "::error::Failed to create release PR automatically after three attempts. Rerun this workflow to reconcile the durable release branch, or open a PR from ${release_branch} to ${DEFAULT_BRANCH}."
+                return "${status}"
               fi
               sleep "$((attempt * 5))"
             done
@@ -1045,24 +1086,39 @@ jobs:
               exit 1
             fi
             git tag -a "${release_tag}" "${RELEASE_COMMIT_SHA}" -m "OpenClaw Cloud Plugin ${release_tag}"
-            bash .github/scripts/retry.sh --label "push release tag" -- git push origin "refs/tags/${release_tag}"
+            tag_attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-tag-push-attempts"
+            if ! RETRY_ATTEMPT_DIR="${tag_attempt_dir}" \
+              bash .github/scripts/retry.sh --label "push release tag" -- \
+                git push origin "refs/tags/${release_tag}"; then
+              report_exhausted_failure "github-release-tag-push" "${tag_attempt_dir}"
+              exit 1
+            fi
           fi
 
           create_release_if_missing
 
-          if [ "${CREATE_VERSION_PR}" = "true" ]; then
-            remote_branch_sha="$(remote_branch_sha "${release_branch}")"
-            if [ -n "${remote_branch_sha}" ]; then
-              if [ "${remote_branch_sha}" != "${RELEASE_COMMIT_SHA}" ]; then
-                echo "::error::Release branch ${release_branch} already exists at a different commit; refusing to overwrite it."
-                exit 1
-              fi
-              echo "Release branch ${release_branch} already points at this commit."
-            else
-              bash .github/scripts/retry.sh --label "push release branch" -- \
-                git push origin "${RELEASE_COMMIT_SHA}:refs/heads/${release_branch}"
+          remote_branch_sha="$(remote_branch_sha "${release_branch}")"
+          should_create_version_pr=false
+          if [ -n "${remote_branch_sha}" ]; then
+            if [ "${remote_branch_sha}" != "${RELEASE_COMMIT_SHA}" ]; then
+              echo "::error::Release branch ${release_branch} already exists at a different commit; refusing to overwrite it."
+              exit 1
             fi
+            echo "Release branch ${release_branch} already points at this commit."
+            should_create_version_pr=true
+          elif [ "${CREATE_VERSION_PR}" = "true" ]; then
+            branch_attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-branch-push-attempts"
+            if ! RETRY_ATTEMPT_DIR="${branch_attempt_dir}" \
+              bash .github/scripts/retry.sh --label "push release branch" -- \
+                git push origin "${RELEASE_COMMIT_SHA}:refs/heads/${release_branch}"; then
+              report_exhausted_failure "github-release-branch-push" "${branch_attempt_dir}"
+              exit 1
+            fi
+            should_create_version_pr=true
+          fi
+
+          if [ "${should_create_version_pr}" = "true" ]; then
             create_pr_if_missing
           else
-            echo "Metadata recovery used npm gitHead ${RELEASE_COMMIT_SHA}; no new version PR was created."
+            echo "Metadata recovery used npm gitHead ${RELEASE_COMMIT_SHA}; no durable release branch exists, so no version PR was created."
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ on:
         required: false
         default: ""
       recover_existing_npm_release:
-        description: "Explicitly allow reconstructing GitHub metadata for a version already on npm. Keep false for normal releases."
+        description: "Backfill missing tag/Release from npm gitHead without republishing. Keep false for normal releases."
         required: true
         type: boolean
         default: false
@@ -78,7 +78,7 @@ on:
         type: string
         default: ""
       recover_existing_npm_release:
-        description: "Allow reconstructing a missing tag/Release for an npm version. Keep false for normal releases."
+        description: "Backfill a missing tag/Release from npm gitHead without republishing. Keep false for normal releases."
         required: false
         type: boolean
         default: false
@@ -134,6 +134,8 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           PUBLISH_CONFIRMATION: ${{ inputs.publish_confirmation }}
           RELEASE_FAULT_CASE: ${{ inputs.fault_case }}
+          RELEASE_GIT_REF: ${{ inputs.git_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           if [[ "${RELEASE_VERSION}" == [vV]* ]]; then
@@ -156,7 +158,122 @@ jobs:
             echo "::error::fault_case is only allowed when dry_run=true."
             exit 1
           fi
+          if [ "${DRY_RUN}" != "true" ] && [ "${GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+            echo "::error::Real releases must be dispatched from the protected default branch ${DEFAULT_BRANCH}; got ${GITHUB_REF}."
+            exit 1
+          fi
+          if [ "${DRY_RUN}" != "true" ] && [ -n "${RELEASE_GIT_REF//[[:space:]]/}" ] && [ "${RELEASE_GIT_REF}" != "${DEFAULT_BRANCH}" ] && [ "${RELEASE_GIT_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+            echo "::error::Real releases cannot override git_ref away from the protected default branch ${DEFAULT_BRANCH}."
+            exit 1
+          fi
           node .github/scripts/validate-release-confirmation.mjs
+
+      - name: Resolve immutable release source
+        id: release_source
+        shell: bash
+        env:
+          PACKAGE_NAME: "@memtensor/memos-cloud-openclaw-plugin"
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          release_tag="v${RELEASE_VERSION#v}"
+          npm_view_log="${RUNNER_TEMP}/openclaw-cloud-plugin-source-version.log"
+          npm_version_exists() {
+            for attempt in 1 2 3; do
+              set +e
+              npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version >"${npm_view_log}" 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                return 0
+              fi
+              if grep -Eiq "E404|404 Not Found|No match found|is not in this registry" "${npm_view_log}"; then
+                return 1
+              fi
+              sed -n '1,120p' "${npm_view_log}" >&2
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to determine whether ${PACKAGE_NAME}@${RELEASE_VERSION} exists."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          npm_release_git_head() {
+            local out="${RUNNER_TEMP}/openclaw-cloud-plugin-source-git-head.log"
+            local git_head
+            for attempt in 1 2 3; do
+              set +e
+              npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" gitHead >"${out}" 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                git_head="$(tr -d '[:space:]"' <"${out}")"
+                if [[ "${git_head}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                  printf '%s\n' "${git_head}"
+                  return 0
+                fi
+                sed -n '1,80p' "${out}" >&2
+                echo "::error::${PACKAGE_NAME}@${RELEASE_VERSION} has no trustworthy 40-character npm gitHead." >&2
+                return 1
+              fi
+              sed -n '1,80p' "${out}" >&2
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to read npm gitHead for ${PACKAGE_NAME}@${RELEASE_VERSION}." >&2
+                return "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          validate_release_commit_versions() {
+            local commit_sha="$1"
+            local file
+            local actual
+            for file in package.json openclaw.plugin.json moltbot.plugin.json clawdbot.plugin.json; do
+              actual="$(
+                git show "${commit_sha}:${file}" |
+                  node -e 'let value=""; process.stdin.on("data", chunk => value += chunk); process.stdin.on("end", () => process.stdout.write(JSON.parse(value).version || ""));'
+              )"
+              if [ "${actual}" != "${RELEASE_VERSION}" ]; then
+                echo "::error::npm gitHead ${commit_sha} has ${file} version ${actual:-missing}, expected ${RELEASE_VERSION}."
+                exit 1
+              fi
+            done
+          }
+
+          evidence_ref=""
+          npm_git_head=""
+          if npm_version_exists; then
+            npm_git_head="$(npm_release_git_head)"
+            if ! git cat-file -e "${npm_git_head}^{commit}" 2>/dev/null; then
+              bash .github/scripts/retry.sh --label "fetch npm gitHead ${npm_git_head}" -- \
+                git fetch --no-tags origin "${npm_git_head}"
+            fi
+            if ! git cat-file -e "${npm_git_head}^{commit}" 2>/dev/null; then
+              echo "::error::npm gitHead ${npm_git_head} is not a commit in ${GITHUB_REPOSITORY}."
+              exit 1
+            fi
+            validate_release_commit_versions "${npm_git_head}"
+
+            if git rev-parse --verify --quiet "${release_tag}^{commit}" >/dev/null; then
+              tag_commit="$(git rev-parse "${release_tag}^{commit}")"
+              if [ "${tag_commit}" != "${npm_git_head}" ]; then
+                echo "::error::Tag ${release_tag} points to ${tag_commit}, but npm records gitHead ${npm_git_head}."
+                exit 1
+              fi
+              evidence_ref="${release_tag}"
+            else
+              evidence_ref="${npm_git_head}"
+              echo "::notice::Tag ${release_tag} is missing; release evidence is pinned to npm gitHead ${npm_git_head}."
+            fi
+          elif git rev-parse --verify --quiet "${release_tag}^{commit}" >/dev/null; then
+            echo "::error::Tag ${release_tag} exists while ${PACKAGE_NAME}@${RELEASE_VERSION} is absent; refusing inconsistent release metadata."
+            exit 1
+          fi
+
+          {
+            echo "evidence_ref=${evidence_ref}"
+            echo "npm_git_head=${npm_git_head}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Install dependencies
         shell: bash
@@ -209,6 +326,7 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.version }}
           RELEASE_TAG: v${{ inputs.version }}
+          RELEASE_EVIDENCE_REF: ${{ steps.release_source.outputs.evidence_ref }}
           MANUAL_RELEASE_NOTES: ${{ inputs.release_notes }}
           RELEASE_FAULT_CASE: ${{ inputs.fault_case }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
@@ -362,6 +480,7 @@ jobs:
           echo "::notice::dry_run=true; skipped npm publish, tag, GitHub Release, and release PR."
 
       - name: Publish to npm
+        id: publish_npm
         if: ${{ inputs.dry_run != true }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -375,6 +494,16 @@ jobs:
           DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
         run: |
           set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          release_tag="v${RELEASE_VERSION#v}"
+          release_branch="release/openclaw-cloud-plugin-${release_tag}"
+          expected_release_prerelease=false
+          if [[ "${RELEASE_VERSION}" == *-* || "${NPM_DIST_TAG}" != "latest" ]]; then
+            expected_release_prerelease=true
+          fi
+
           npm_view_log="${RUNNER_TEMP}/openclaw-cloud-plugin-npm-view.log"
           npm_version_exists() {
             for attempt in 1 2 3; do
@@ -397,6 +526,59 @@ jobs:
               sleep "$((attempt * 5))"
             done
           }
+          npm_release_git_head() {
+            local out="${RUNNER_TEMP}/openclaw-cloud-plugin-npm-git-head.log"
+            local git_head
+            for attempt in 1 2 3; do
+              set +e
+              npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" gitHead >"${out}" 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                git_head="$(tr -d '[:space:]"' <"${out}")"
+                if [[ "${git_head}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                  printf '%s\n' "${git_head}"
+                  return 0
+                fi
+                sed -n '1,80p' "${out}" >&2
+                echo "::error::${PACKAGE_NAME}@${RELEASE_VERSION} has no trustworthy 40-character npm gitHead." >&2
+                return 1
+              fi
+              sed -n '1,80p' "${out}" >&2
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to read npm gitHead for ${PACKAGE_NAME}@${RELEASE_VERSION} after three attempts." >&2
+                return "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          ensure_commit_available() {
+            local commit_sha="$1"
+            if git cat-file -e "${commit_sha}^{commit}" 2>/dev/null; then
+              return 0
+            fi
+            bash .github/scripts/retry.sh --label "fetch npm gitHead ${commit_sha}" -- \
+              git fetch --no-tags origin "${commit_sha}"
+            if ! git cat-file -e "${commit_sha}^{commit}" 2>/dev/null; then
+              echo "::error::npm gitHead ${commit_sha} is not a commit in ${GITHUB_REPOSITORY}."
+              exit 1
+            fi
+          }
+          validate_release_commit_versions() {
+            local commit_sha="$1"
+            local file
+            local actual
+            for file in package.json openclaw.plugin.json moltbot.plugin.json clawdbot.plugin.json; do
+              actual="$(
+                git show "${commit_sha}:${file}" |
+                  node -e 'let value=""; process.stdin.on("data", chunk => value += chunk); process.stdin.on("end", () => process.stdout.write(JSON.parse(value).version || ""));'
+              )"
+              if [ "${actual}" != "${RELEASE_VERSION}" ]; then
+                echo "::error::npm gitHead ${commit_sha} has ${file} version ${actual:-missing}, expected ${RELEASE_VERSION}."
+                exit 1
+              fi
+            done
+          }
           remote_tag_exists() {
             local release_tag="$1"
             for attempt in 1 2 3; do
@@ -417,43 +599,105 @@ jobs:
               sleep "$((attempt * 5))"
             done
           }
-          github_release_exists() {
-            local release_tag="$1"
-            local out="${RUNNER_TEMP}/openclaw-cloud-plugin-release-view.log"
+          remote_branch_sha() {
+            local branch="$1"
+            local out="${RUNNER_TEMP}/openclaw-cloud-plugin-remote-branch.txt"
             for attempt in 1 2 3; do
               set +e
-              gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >"${out}" 2>&1
+              git ls-remote --heads origin "${branch}" >"${out}" 2>&1
               status=$?
               set -e
               if [ "${status}" = 0 ]; then
+                awk '{print $1}' "${out}"
                 return 0
               fi
-              if grep -Eiq "not found|could not find|HTTP 404" "${out}"; then
-                return 1
-              fi
-              sed -n '1,120p' "${out}"
+              sed -n '1,120p' "${out}" >&2
               if [ "${attempt}" = 3 ]; then
-                echo "::error::Failed to check GitHub Release ${release_tag} after three attempts."
+                echo "::error::Failed to check remote branch ${branch} after three attempts."
                 exit "${status}"
               fi
               sleep "$((attempt * 5))"
             done
           }
+          release_inventory_file="${RUNNER_TEMP}/openclaw-cloud-plugin-release-inventory.json"
+          refresh_release_inventory() {
+            local out="${release_inventory_file}.tmp"
+            local err="${release_inventory_file}.err"
+            for attempt in 1 2 3; do
+              set +e
+              gh api --paginate --slurp \
+                "repos/${GITHUB_REPOSITORY}/releases?per_page=100" >"${out}" 2>"${err}"
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                mv "${out}" "${release_inventory_file}"
+                return 0
+              fi
+              sed -n '1,120p' "${err}" >&2
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to enumerate GitHub Releases after three attempts."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          inspect_release_inventory() {
+            local expected_target="${1:-}"
+            RELEASE_INVENTORY_FILE="${release_inventory_file}" \
+              RELEASE_TAG="${release_tag}" \
+              EXPECTED_RELEASE_DRAFT=false \
+              EXPECTED_RELEASE_PRERELEASE="${expected_release_prerelease}" \
+              EXPECTED_RELEASE_TARGET="${expected_target}" \
+              REQUIRED_DOC_AGENT_SOURCE_ID=openclaw-cloud-plugin \
+              REQUIRE_EXISTING_RELEASE=false \
+              node .github/scripts/validate-github-release-inventory.mjs
+          }
 
+          tag_exists=false
+          tag_commit=""
+          if remote_tag_exists "${release_tag}"; then
+            tag_exists=true
+            git fetch --force origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+            tag_commit="$(git rev-parse "${release_tag}^{commit}")"
+          fi
+
+          refresh_release_inventory
+          set +e
+          release_inventory_report="$(inspect_release_inventory "")"
+          release_inventory_status=$?
+          set -e
+          if [ "${release_inventory_status}" -ne 0 ]; then
+            echo "::error::${release_inventory_report}"
+            exit 1
+          fi
+          release_state="$(printf '%s' "${release_inventory_report}" | jq -r '.state')"
+          release_exists=false
+          if [ "${release_state}" = "existing" ]; then
+            release_exists=true
+          fi
+
+          create_version_pr=false
+          existing_release_branch_sha="$(remote_branch_sha "${release_branch}")"
           if npm_version_exists; then
-            release_tag="v${RELEASE_VERSION}"
-            tag_exists=false
-            release_exists=false
-            if remote_tag_exists "${release_tag}"; then
-              tag_exists=true
+            release_commit_sha="$(npm_release_git_head)"
+            ensure_commit_available "${release_commit_sha}"
+            validate_release_commit_versions "${release_commit_sha}"
+
+            if [ -n "${existing_release_branch_sha}" ]; then
+              if [ "${existing_release_branch_sha}" != "${release_commit_sha}" ]; then
+                echo "::error::Release branch ${release_branch} points to ${existing_release_branch_sha}, but npm records gitHead ${release_commit_sha}."
+                exit 1
+              fi
+              create_version_pr=true
             fi
-            if github_release_exists "${release_tag}"; then
-              release_exists=true
+            if [ "${tag_exists}" = "true" ] && [ "${tag_commit}" != "${release_commit_sha}" ]; then
+              echo "::error::Tag ${release_tag} points to ${tag_commit}, but npm ${PACKAGE_NAME}@${RELEASE_VERSION} records gitHead ${release_commit_sha}."
+              exit 1
             fi
             if [ "${tag_exists}" = "true" ] && [ "${release_exists}" = "true" ]; then
-              echo "${PACKAGE_NAME}@${RELEASE_VERSION}, ${release_tag}, and the GitHub Release already exist; treating this as an idempotent rerun."
+              echo "${PACKAGE_NAME}@${RELEASE_VERSION}, ${release_tag}, and its validated GitHub Release already exist; treating this as an idempotent rerun."
             elif [ "${RECOVER_EXISTING_NPM_RELEASE}" = "true" ]; then
-              echo "Recovery mode enabled; npm version exists, so publish is skipped and missing GitHub metadata may be reconstructed."
+              echo "Recovery mode enabled; npm version exists, so publish is skipped and missing GitHub metadata will target npm gitHead ${release_commit_sha}."
             else
               missing=()
               if [ "${tag_exists}" != "true" ]; then
@@ -464,12 +708,44 @@ jobs:
               fi
               printf -v missing_text "%s, " "${missing[@]}"
               missing_text="${missing_text%, }"
-              echo "::error::${PACKAGE_NAME}@${RELEASE_VERSION} already exists on npm, but ${missing_text} is missing. Set recover_existing_npm_release=true only for an intentional metadata backfill."
+              echo "::error::${PACKAGE_NAME}@${RELEASE_VERSION} already exists on npm, but ${missing_text} is missing. Set recover_existing_npm_release=true only for an intentional metadata backfill pinned to npm gitHead."
               exit 1
             fi
           else
+            if [ "${tag_exists}" = "true" ] || [ "${release_exists}" = "true" ]; then
+              echo "::error::Refusing to publish ${PACKAGE_NAME}@${RELEASE_VERSION}: GitHub tag/Release metadata already exists while npm does not."
+              exit 1
+            fi
+
+            source_commit_sha="$(git rev-parse HEAD)"
+            if [ -n "${existing_release_branch_sha}" ]; then
+              ensure_commit_available "${existing_release_branch_sha}"
+              if [ "${existing_release_branch_sha}" != "${source_commit_sha}" ]; then
+                release_parent_sha="$(git rev-parse "${existing_release_branch_sha}^")"
+                if [ "${release_parent_sha}" != "${source_commit_sha}" ]; then
+                  echo "::error::Release branch ${release_branch} is based on ${release_parent_sha}, expected current source ${source_commit_sha}."
+                  exit 1
+                fi
+              fi
+              validate_release_commit_versions "${existing_release_branch_sha}"
+              git checkout --detach --force "${existing_release_branch_sha}"
+              release_commit_sha="${existing_release_branch_sha}"
+              echo "Reusing durable release commit ${release_commit_sha} after an earlier interrupted publish."
+            else
+              git add package.json openclaw.plugin.json moltbot.plugin.json clawdbot.plugin.json
+              if ! git diff --staged --quiet; then
+                git commit -m "release: @memtensor/memos-cloud-openclaw-plugin ${release_tag}"
+              fi
+              release_commit_sha="$(git rev-parse HEAD)"
+              validate_release_commit_versions "${release_commit_sha}"
+              bash .github/scripts/retry.sh --label "push durable release branch" -- \
+                git push origin "${release_commit_sha}:refs/heads/${release_branch}"
+            fi
+            create_version_pr=true
+
             attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-npm-publish-attempts"
             mkdir -p "${attempt_dir}"
+            publish_confirmed=false
             for attempt in 1 2 3; do
               set +e
               npm publish --access public --tag "${NPM_DIST_TAG}" >"${attempt_dir}/${attempt}.log" 2>&1
@@ -477,10 +753,28 @@ jobs:
               set -e
               sed -n '1,160p' "${attempt_dir}/${attempt}.log"
               if [ "${publish_status}" = 0 ]; then
+                for poll_attempt in 1 2 3; do
+                  if npm_version_exists; then
+                    publish_confirmed=true
+                    break
+                  fi
+                  sleep "$((poll_attempt * 2))"
+                done
+                if [ "${publish_confirmed}" != "true" ]; then
+                  echo "::error::npm publish returned success, but the version could not be verified. Refusing to issue a second publish request."
+                  exit 1
+                fi
                 break
               fi
-              if npm_version_exists; then
-                echo "Publish returned an error, but npm now contains the requested version."
+              for poll_attempt in 1 2 3; do
+                if npm_version_exists; then
+                  publish_confirmed=true
+                  break
+                fi
+                sleep "$((poll_attempt * 2))"
+              done
+              if [ "${publish_confirmed}" = "true" ]; then
+                echo "Publish returned an error, but npm now contains the requested version; refusing a duplicate publish."
                 break
               fi
               if [ "${attempt}" = 3 ]; then
@@ -493,11 +787,21 @@ jobs:
               fi
               sleep "$((attempt * 5))"
             done
-            if ! npm_version_exists; then
+            if [ "${publish_confirmed}" != "true" ]; then
               echo "::error::npm publish appeared to finish, but ${PACKAGE_NAME}@${RELEASE_VERSION} is still not visible."
               exit 1
             fi
+            npm_git_head="$(npm_release_git_head)"
+            if [ "${npm_git_head}" != "${release_commit_sha}" ]; then
+              echo "::error::Published npm gitHead ${npm_git_head} does not match release commit ${release_commit_sha}."
+              exit 1
+            fi
           fi
+
+          {
+            echo "release_commit_sha=${release_commit_sha}"
+            echo "create_version_pr=${create_version_pr}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Create release tag, GitHub Release, and version PR
         if: ${{ inputs.dry_run != true }}
@@ -506,11 +810,21 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
           NPM_DIST_TAG: ${{ inputs.tag }}
           RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
+          RELEASE_COMMIT_SHA: ${{ steps.publish_npm.outputs.release_commit_sha }}
+          CREATE_VERSION_PR: ${{ steps.publish_npm.outputs.create_version_pr }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           if [ -z "${RELEASE_NOTES_FILE}" ] || [ ! -s "${RELEASE_NOTES_FILE}" ]; then
             echo "::error::Release notes file was not generated."
+            exit 1
+          fi
+          if ! [[ "${RELEASE_COMMIT_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::Publish step did not provide a trustworthy release commit SHA."
+            exit 1
+          fi
+          if ! git cat-file -e "${RELEASE_COMMIT_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::Release commit ${RELEASE_COMMIT_SHA} is not available locally."
             exit 1
           fi
 
@@ -520,6 +834,10 @@ jobs:
           release_tag="v${RELEASE_VERSION#v}"
           release_branch="release/openclaw-cloud-plugin-${release_tag}"
           release_title="release: @memtensor/memos-cloud-openclaw-plugin ${release_tag}"
+          expected_release_prerelease=false
+          if [[ "${RELEASE_VERSION}" == *-* || "${NPM_DIST_TAG}" != "latest" ]]; then
+            expected_release_prerelease=true
+          fi
           remote_branch_sha() {
             local branch="$1"
             local out="${RUNNER_TEMP}/openclaw-cloud-plugin-remote-branch.txt"
@@ -560,39 +878,118 @@ jobs:
               sleep "$((attempt * 5))"
             done
           }
-          create_release_if_missing() {
-            release_flags=()
-            if [[ "${RELEASE_VERSION}" == *-* || "${NPM_DIST_TAG}" != "latest" ]]; then
-              release_flags+=(--prerelease)
-              echo "Marking GitHub Release ${release_tag} as prerelease because version=${RELEASE_VERSION}, npm_dist_tag=${NPM_DIST_TAG}."
-            fi
+          release_inventory_file="${RUNNER_TEMP}/openclaw-cloud-plugin-release-inventory.json"
+          refresh_release_inventory() {
+            local out="${release_inventory_file}.tmp"
+            local err="${release_inventory_file}.err"
             for attempt in 1 2 3; do
-              if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-                echo "GitHub Release ${release_tag} already exists; leaving it unchanged."
-                return 0
-              fi
               set +e
-              gh release create "${release_tag}" \
-                --repo "${GITHUB_REPOSITORY}" \
-                --target "$(git rev-parse HEAD)" \
-                --title "OpenClaw Cloud Plugin ${release_tag}" \
-                --notes-file "${RELEASE_NOTES_FILE}" \
-                "${release_flags[@]}"
+              gh api --paginate --slurp \
+                "repos/${GITHUB_REPOSITORY}/releases?per_page=100" >"${out}" 2>"${err}"
               status=$?
               set -e
               if [ "${status}" = 0 ]; then
+                mv "${out}" "${release_inventory_file}"
                 return 0
               fi
+              sed -n '1,120p' "${err}" >&2
               if [ "${attempt}" = 3 ]; then
-                if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-                  echo "GitHub Release ${release_tag} exists after a failed create response; treating as success."
-                  return 0
-                fi
-                echo "::error::Failed to create GitHub Release ${release_tag} after three attempts."
+                echo "::error::Failed to enumerate GitHub Releases after three attempts."
                 exit "${status}"
               fi
               sleep "$((attempt * 5))"
             done
+          }
+          inspect_release_inventory() {
+            local require_existing="$1"
+            RELEASE_INVENTORY_FILE="${release_inventory_file}" \
+              RELEASE_TAG="${release_tag}" \
+              EXPECTED_RELEASE_DRAFT=false \
+              EXPECTED_RELEASE_PRERELEASE="${expected_release_prerelease}" \
+              EXPECTED_RELEASE_TARGET="${RELEASE_COMMIT_SHA}" \
+              REQUIRED_DOC_AGENT_SOURCE_ID=openclaw-cloud-plugin \
+              REQUIRE_EXISTING_RELEASE="${require_existing}" \
+              node .github/scripts/validate-github-release-inventory.mjs
+          }
+          create_release_if_missing() {
+            local release_flags=()
+            if [ "${expected_release_prerelease}" = "true" ]; then
+              release_flags+=(--prerelease)
+              echo "Marking GitHub Release ${release_tag} as prerelease because version=${RELEASE_VERSION}, npm_dist_tag=${NPM_DIST_TAG}."
+            fi
+
+            for attempt in 1 2 3; do
+              refresh_release_inventory
+              set +e
+              release_inventory_report="$(inspect_release_inventory false)"
+              release_inventory_status=$?
+              set -e
+              release_inventory_state="$(
+                printf '%s' "${release_inventory_report}" |
+                  jq -r '.state // "invalid"'
+              )"
+              if [ "${release_inventory_status}" -eq 0 ] && [ "${release_inventory_state}" = "existing" ]; then
+                echo "GitHub Release ${release_tag} already exists with matching source metadata; leaving it unchanged."
+                return 0
+              fi
+              if [ "${release_inventory_status}" -ne 0 ] || [ "${release_inventory_state}" != "absent" ]; then
+                echo "::error::${release_inventory_report}"
+                exit 1
+              fi
+
+              echo "::group::create GitHub Release attempt ${attempt}/3"
+              set +e
+              gh release create "${release_tag}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --target "${RELEASE_COMMIT_SHA}" \
+                --title "OpenClaw Cloud Plugin ${release_tag}" \
+                --notes-file "${RELEASE_NOTES_FILE}" \
+                "${release_flags[@]}"
+              create_status=$?
+              set -e
+              echo "::endgroup::"
+
+              release_verified=false
+              for poll_attempt in 1 2 3; do
+                refresh_release_inventory
+                set +e
+                release_inventory_report="$(inspect_release_inventory true)"
+                release_inventory_status=$?
+                set -e
+                release_inventory_state="$(
+                  printf '%s' "${release_inventory_report}" |
+                    jq -r '.state // "invalid"'
+                )"
+                if [ "${release_inventory_status}" -eq 0 ]; then
+                  if [ "${create_status}" -ne 0 ]; then
+                    echo "::notice::GitHub Release ${release_tag} exists with correct metadata after an unsuccessful create response."
+                  fi
+                  release_verified=true
+                  break
+                fi
+                if [ "${release_inventory_state}" != "absent" ]; then
+                  echo "::error::${release_inventory_report}"
+                  exit 1
+                fi
+                if [ "${poll_attempt}" -lt 3 ]; then
+                  sleep "$((poll_attempt * 2))"
+                fi
+              done
+
+              if [ "${release_verified}" = "true" ]; then
+                return 0
+              fi
+              if [ "${create_status}" -eq 0 ]; then
+                echo "::error::GitHub reported a successful Release create, but ${release_tag} could not be verified. Refusing to issue a second create request."
+                exit 1
+              fi
+              if [ "${attempt}" -lt 3 ]; then
+                sleep "$((attempt * 5))"
+              fi
+            done
+
+            echo "::error::Failed to create and verify GitHub Release ${release_tag} after three attempts."
+            exit 1
           }
           create_pr_if_missing() {
             if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
@@ -624,37 +1021,48 @@ jobs:
             done
           }
 
-          git add package.json openclaw.plugin.json moltbot.plugin.json clawdbot.plugin.json
-          created_release_commit=false
-          if ! git diff --staged --quiet; then
-            git commit -m "${release_title}"
-            created_release_commit=true
-          fi
-
-          if [ "${created_release_commit}" = "true" ]; then
-            remote_branch_sha="$(remote_branch_sha "${release_branch}")"
-            if [ -n "${remote_branch_sha}" ]; then
-              if [ "${remote_branch_sha}" != "$(git rev-parse HEAD)" ]; then
-                echo "::error::Release branch ${release_branch} already exists at a different commit; refusing to overwrite it."
-                exit 1
-              fi
-              echo "Release branch ${release_branch} already points at this commit."
-            else
-              bash .github/scripts/retry.sh --label "push release branch" -- git push origin "HEAD:refs/heads/${release_branch}"
-            fi
+          refresh_release_inventory
+          set +e
+          release_inventory_report="$(inspect_release_inventory false)"
+          release_inventory_status=$?
+          set -e
+          if [ "${release_inventory_status}" -ne 0 ]; then
+            echo "::error::${release_inventory_report}"
+            exit 1
           fi
 
           if remote_tag_exists "${release_tag}"; then
-            echo "Tag ${release_tag} already exists on origin; leaving it unchanged."
+            git fetch --force origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+            actual_tag_commit="$(git rev-parse "${release_tag}^{commit}")"
+            if [ "${actual_tag_commit}" != "${RELEASE_COMMIT_SHA}" ]; then
+              echo "::error::Tag ${release_tag} points to ${actual_tag_commit}, expected npm gitHead ${RELEASE_COMMIT_SHA}."
+              exit 1
+            fi
+            echo "Tag ${release_tag} already points to npm gitHead ${RELEASE_COMMIT_SHA}; leaving it unchanged."
           else
-            git tag "${release_tag}"
+            if git rev-parse --verify "refs/tags/${release_tag}" >/dev/null 2>&1; then
+              echo "::error::A local-only tag ${release_tag} exists while the remote tag is absent; refusing to overwrite or guess."
+              exit 1
+            fi
+            git tag -a "${release_tag}" "${RELEASE_COMMIT_SHA}" -m "OpenClaw Cloud Plugin ${release_tag}"
             bash .github/scripts/retry.sh --label "push release tag" -- git push origin "refs/tags/${release_tag}"
           fi
 
           create_release_if_missing
 
-          if [ "${created_release_commit}" = "true" ]; then
+          if [ "${CREATE_VERSION_PR}" = "true" ]; then
+            remote_branch_sha="$(remote_branch_sha "${release_branch}")"
+            if [ -n "${remote_branch_sha}" ]; then
+              if [ "${remote_branch_sha}" != "${RELEASE_COMMIT_SHA}" ]; then
+                echo "::error::Release branch ${release_branch} already exists at a different commit; refusing to overwrite it."
+                exit 1
+              fi
+              echo "Release branch ${release_branch} already points at this commit."
+            else
+              bash .github/scripts/retry.sh --label "push release branch" -- \
+                git push origin "${RELEASE_COMMIT_SHA}:refs/heads/${release_branch}"
+            fi
             create_pr_if_missing
           else
-            echo "No version bump changes to open as a PR."
+            echo "Metadata recovery used npm gitHead ${RELEASE_COMMIT_SHA}; no new version PR was created."
           fi

--- a/.github/workflows/workflow-contract-lint.yml
+++ b/.github/workflows/workflow-contract-lint.yml
@@ -1,0 +1,57 @@
+name: OpenClaw Cloud Plugin — Workflow Contract Lint
+
+on:
+  push:
+    branches:
+      - main
+      - "docs-sync/**"
+    paths:
+      - ".github/workflows/**"
+      - ".github/scripts/validate-github-release-inventory.mjs"
+      - ".github/scripts/validate-github-release-inventory.test.mjs"
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install verified actionlint
+        shell: bash
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_LINUX_AMD64_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/actionlint.tar.gz"
+          binary="${RUNNER_TEMP}/actionlint"
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl --fail --location --retry 3 --retry-all-errors \
+            --output "${archive}" "${url}"
+          printf '%s  %s\n' "${ACTIONLINT_LINUX_AMD64_SHA256}" "${archive}" |
+            sha256sum --check -
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}" actionlint
+          "${binary}" -version
+          "${binary}" -color
+
+  release-contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Validate reusable workflow boundaries
+        shell: bash
+        run: node --test .github/scripts/validate-github-release-inventory.test.mjs

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "telemetry.credentials.json"
   ],
   "scripts": {
-    "test": "node --test .github/scripts/draft-cloud-plugin-release-notes.test.mjs test/*.test.mjs",
+    "test": "node --test .github/scripts/*.test.mjs test/*.test.mjs",
     "generate-telemetry-credentials": "node scripts/generate-telemetry-credentials.cjs",
     "sync-version": "node scripts/sync-version.js",
     "version": "npm run sync-version && git add openclaw.plugin.json moltbot.plugin.json clawdbot.plugin.json",


### PR DESCRIPTION
## What changed

- Bind cloud-plugin release notes to the immutable git evidence range before accepting drafted or manual notes.
- Enforce bilingual structure, real `source_refs`, important-commit coverage, Plugin-tab readability, and at most three semantic repair requests.
- Send the exact validation report and previous draft items back to the drafter on every semantic repair.
- Report three exhausted semantic-repair attempts to the Doc Agent failure endpoint without allowing a failure-sink outage to hide the original release error.
- Emit `quality-report.json` with limits, coverage, issues, validation attempts, repair attempts, and deterministic postprocessing details.
- Upload inspection artifacts even when release-note validation fails closed.
- Add dry-run-only fault injection for language, missing/fabricated refs, important-commit coverage, item count, item length, and missing manual payload.
- Exclude release/CI/build/test/docs/version evidence from user-facing notes and normalize full/short SHA aliases to one short SHA while preserving real `#PR` refs.
- Keep stable Release/Docs evidence ranges pinned to the previous stable tag, so product changes introduced in preview tags are not omitted when prereleases skip formal Docs updates.
- Reject incompatible SemVer/npm dist-tag pairs before both dry-run and publish: stable versions require `latest`, while prerelease versions require a non-`latest` preview channel.
- Reconcile npm, durable release branches, tags, GitHub Release inventory/create/verification, and version PR creation against authoritative remote state.
- Capture and sanitize exhausted external-attempt logs before reporting them.
- Reconcile an existing durable release branch on rerun so a failed version-PR creation can be completed without republishing npm or recreating the Release.
- Fail the workflow after three version-PR creation failures instead of showing a misleading successful release workflow.
- Separate the reusable inspection path from the manual publisher: `release-dry-run.yml` is fixed to `contents: read`, has no npm token or publish/Release commands, and checks out with `persist-credentials: false`.
- Make `release.yml` dispatch-only so a branch-controlled caller cannot request its write-capable token; manual dry-runs also avoid persisting repository credentials.
- Keep pre-merge validation secretless with a checked-in evidence-backed fixture. Trusted post-merge/historical callers pass only the explicit Doc Agent/telemetry allowlist and never pass `NPM_TOKEN`.

## Validation

Local:

- Release/workflow tests: 53/53 passed.
- Plugin tests: 46/46 passed.
- Total: 99/99 passed.
- Stable-channel regression coverage verifies that a stable release ignores same-version prerelease tags when selecting the previous evidence boundary.
- Channel validation rejects prerelease versions on `latest` and stable versions on preview dist-tags.
- Official `actionlint` v1.7.12 reports zero errors across all five workflow files.
- All five workflow YAML files parsed and all 22 Bash `run:` blocks passed `bash -n`.
- `npm pack --dry-run --json` passed; the inspection artifact includes the package inventory without workflow/test files.
- `git diff --check` passed.

Latest production-repository branch dry-run:

- [Run 30258484314](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin/actions/runs/30258484314): success on `31a1749771b110068889634136a6a98ca75765f0`.
- Both `secrets-preflight` and `dry-run / inspect` completed successfully.
- The reusable job recorded `contents:read` and `repository_credentials_persisted: false`.
- Evidence range: `v0.1.18..v0.1.19`.
- Output: 2 bilingual Plugin-tab items, both grounded in `d053b0a`.
- Quality: `ok=true`, `needs_review=false`, 0 issues, 0 invalid refs, 0 missing required commits.
- Attempts: 1 validation, 0 repairs.
- Artifact: 8 inspection files, including `quality-report.json`, redacted `evidence.json`, npm pack inventory, and Chinese/English Docs previews.

Formal-repository fault matrix, all with `dry_run=true`:

- [mixed_language 30236521707](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin/actions/runs/30236521707)
- [missing_source_refs 30236570897](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin/actions/runs/30236570897)
- [missing_important_commit 30236600450](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin/actions/runs/30236600450)
- [invalid_source_ref 30236632778](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin/actions/runs/30236632778)
- [thirteen_items 30236663999](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin/actions/runs/30236663999)
- [too_long 30236696527](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin/actions/runs/30236696527)

Each repairable fault completed with exactly 2 validation attempts and 1 repair. [manual_notes_missing_payload 30236722719](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin/actions/runs/30236722719) failed closed as expected while still uploading its inspection artifact.

## Safety boundary

- Every remote validation used `dry_run=true`.
- npm publish, tag creation, GitHub Release creation, version PR creation, and MemOS-Docs writes were skipped.
- No OSS, pre, gray, production deployment, or DingTalk notification was triggered.
- This PR does not deploy the Doc Agent service. Receiver hardening remains in its separately reviewed PR and server rollout remains an explicit deployment step.
- A real npm/Release/webhook/Docs release still requires explicit release authorization after this PR is reviewed and merged.
