### PR TITLE
ci: publish reviewed main versions without Actions PRs

### DIFF
--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -97,7 +97,7 @@ test("verifies target, release flags, and the exact production source id", () =>
   assert.ok(invalid.errors.some((error) => /exactly one Doc Agent source id/.test(error)));
 });
 
-test("release workflow pins recovery to npm gitHead and reconciles create responses", () => {
+test("release workflow publishes committed main versions and pins recovery to npm gitHead", () => {
   const workflow = readFileSync(
     new URL("../workflows/release.yml", import.meta.url),
     "utf8",
@@ -119,11 +119,31 @@ test("release workflow pins recovery to npm gitHead and reconciles create respon
     workflow,
     /git tag -a "\$\{release_tag\}" "\$\{RELEASE_COMMIT_SHA\}"/,
   );
-  assert.match(workflow, /push durable release branch/);
+  assert.match(workflow, /Validate committed release source version/);
+  assert.match(workflow, /validate-release-source-version\.mjs/);
+  assert.match(
+    workflow,
+    /Publishing the already-reviewed \$\{DEFAULT_BRANCH\} commit \$\{release_commit_sha\}/,
+  );
+  assert.match(workflow, /is no longer the head of \$\{DEFAULT_BRANCH\}/);
+  assert.match(
+    workflow,
+    /Normal real releases require git_ref to be the exact 40-character source_commit approved in the dry-run/,
+  );
+  assert.match(
+    workflow,
+    /Recovery requires \$\{PACKAGE_NAME\}@\$\{RELEASE_VERSION\} to already exist on npm/,
+  );
+  assert.match(workflow, /release-source\.json/);
+  assert.match(
+    workflow,
+    /EXPECTED_RELEASE_PRERELEASE: \$\{\{ steps\.release_policy\.outputs\.github_release_prerelease \}\}/,
+  );
+  assert.match(workflow, /release_flags\+=\(--prerelease\)/);
   assert.ok(
-    workflow.indexOf("push durable release branch") <
+    workflow.indexOf("Validate committed release source version") <
       workflow.indexOf('npm publish --access public --tag "${NPM_DIST_TAG}"'),
-    "the recoverable release commit must be pushed before npm publish",
+    "the committed source version gate must run before npm publish",
   );
   assert.match(
     workflow,
@@ -137,21 +157,15 @@ test("release workflow pins recovery to npm gitHead and reconciles create respon
   assert.match(workflow, /report_exhausted_failure "github-release-create"/);
   assert.match(workflow, /report_exhausted_failure "github-release-verification"/);
   assert.match(workflow, /report_exhausted_failure "github-release-tag-push"/);
-  assert.match(workflow, /report_exhausted_failure "github-release-branch-push"/);
-  assert.match(workflow, /report_exhausted_failure "github-release-pr-create"/);
-  assert.match(workflow, /should_create_version_pr=true/);
-  assert.match(
-    workflow,
-    /Release branch \$\{release_branch\} already points at this commit\.[\s\S]+should_create_version_pr=true/,
-  );
-  assert.match(
-    workflow,
-    /::error::Failed to create release PR automatically after three attempts/,
-  );
   assert.doesNotMatch(
     workflow,
-    /::warning::Failed to create release PR automatically after three attempts/,
+    /npm version "\$\{RELEASE_VERSION\}".*--no-git-tag-version/,
   );
+  assert.doesNotMatch(workflow, /npm run sync-version/);
+  assert.doesNotMatch(workflow, /pull-requests: write/);
+  assert.doesNotMatch(workflow, /gh pr create/);
+  assert.doesNotMatch(workflow, /release_branch/);
+  assert.doesNotMatch(workflow, /create_version_pr/);
   assert.doesNotMatch(workflow, /gh release view/);
 });
 
@@ -232,10 +246,29 @@ test("dry-run callers use least privilege and do not inherit all repository secr
     assert.doesNotMatch(workflow, /pull-requests: write/);
   }
 
+  const postMerge = readFileSync(
+    new URL("../workflows/post-merge-dry-run.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(postMerge, /version: \$\{\{ needs\.release_source\.outputs\.version \}\}/);
+  assert.match(
+    postMerge,
+    /expected_current_ref: \$\{\{ needs\.release_source\.outputs\.source_sha \}\}/,
+  );
+  assert.match(postMerge, /enforce_source_version: true/);
+  assert.doesNotMatch(postMerge, /version: "0\.1\.19"/);
+
+  const preMergeDryRun = readFileSync(
+    new URL("../workflows/pre-merge-dry-run.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(preMergeDryRun, /enforce_source_version: false/);
+
   const historical = readFileSync(
     new URL("../workflows/historical-dry-run.yml", import.meta.url),
     "utf8",
   );
+  assert.match(historical, /enforce_source_version: false/);
   assert.match(historical, /github\.event\.repository\.default_branch/);
   for (const [version, previousTag] of [
     ["0.1.15", "v0.1.14"],
@@ -265,7 +298,7 @@ test("dry-run callers use least privilege and do not inherit all repository secr
   );
   assert.match(
     contractLint,
-    /node --test \.github\/scripts\/validate-github-release-inventory\.test\.mjs/,
+    /node --test \.github\/scripts\/validate-github-release-inventory\.test\.mjs \.github\/scripts\/validate-release-confirmation\.test\.mjs \.github\/scripts\/validate-release-source-version\.test\.mjs/,
   );
   assert.doesNotMatch(contractLint, /secrets:/);
   assert.doesNotMatch(contractLint, /contents: write/);

--- a/.github/scripts/validate-release-confirmation.mjs
+++ b/.github/scripts/validate-release-confirmation.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { appendFileSync } from "node:fs";
 import { cleanVersion, parseSemver } from "../../lib/semver.js";
 
 export function expectedReleaseConfirmation(version) {
@@ -21,28 +22,34 @@ export function validateReleaseChannel({ version, npmDistTag }) {
   }
 
   const isPrerelease = parsed.prerelease.length > 0;
-  if (isPrerelease && tag === "latest") {
+  const prereleaseIdentifier = isPrerelease
+    ? String(parsed.prerelease[0] || "").toLowerCase()
+    : "";
+  const expectedNpmDistTag = isPrerelease
+    ? ["alpha", "beta", "next"].includes(prereleaseIdentifier)
+      ? prereleaseIdentifier
+      : "next"
+    : "latest";
+
+  if (tag !== expectedNpmDistTag) {
     return {
       ok: false,
-      reason:
-        `prerelease version ${cleanVersion(version)} cannot use npm dist-tag 'latest'; ` +
-        "use beta, next, alpha, or another non-latest preview channel.",
-    };
-  }
-  if (!isPrerelease && tag !== "latest") {
-    return {
-      ok: false,
-      reason:
-        `stable version ${cleanVersion(version)} must use npm dist-tag 'latest'; ` +
-        `got '${tag}'. This workflow does not support promoting a stable version from '${tag}' later.`,
+      reason: isPrerelease
+        ? `prerelease version ${cleanVersion(version)} must use npm dist-tag '${expectedNpmDistTag}'; got '${tag}'.`
+        : `stable version ${cleanVersion(version)} must use npm dist-tag 'latest'; got '${tag}'.`,
     };
   }
 
   return {
     ok: true,
+    release_channel: isPrerelease ? "prerelease" : "stable",
+    prerelease_identifier: prereleaseIdentifier,
+    expected_npm_dist_tag: expectedNpmDistTag,
+    github_release_prerelease: isPrerelease,
+    docs_sync_expected: !isPrerelease,
     reason: isPrerelease
-      ? `prerelease version and npm dist-tag '${tag}' are compatible.`
-      : "stable version and npm dist-tag 'latest' are compatible.",
+      ? `prerelease version will publish on npm '${tag}', create a GitHub Prerelease, and skip formal Docs sync.`
+      : "stable version will publish on npm 'latest', create a published GitHub Release, and enter formal Docs sync.",
   };
 }
 
@@ -98,6 +105,20 @@ export function main(env = process.env) {
   console.log(result.reason);
   if (result.expected) {
     console.log(`Expected confirmation: ${result.expected}`);
+  }
+  if (env.GITHUB_OUTPUT) {
+    appendFileSync(
+      env.GITHUB_OUTPUT,
+      [
+        `release_channel=${channel.release_channel}`,
+        `prerelease_identifier=${channel.prerelease_identifier}`,
+        `npm_dist_tag=${channel.expected_npm_dist_tag}`,
+        `github_release_prerelease=${channel.github_release_prerelease}`,
+        `docs_sync_expected=${channel.docs_sync_expected}`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
   }
 }
 

--- a/.github/scripts/validate-release-confirmation.test.mjs
+++ b/.github/scripts/validate-release-confirmation.test.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import {
   expectedReleaseConfirmation,
+  main,
   validateReleaseChannel,
   validateReleaseConfirmation,
 } from "./validate-release-confirmation.mjs";
@@ -24,16 +28,40 @@ test("does not require publish confirmation for dry runs", () => {
 });
 
 test("requires stable versions to use latest and prereleases to use a preview channel", () => {
-  assert.equal(validateReleaseChannel({ version: "0.1.20", npmDistTag: "latest" }).ok, true);
-  assert.equal(validateReleaseChannel({ version: "0.1.20-beta.1", npmDistTag: "beta" }).ok, true);
-  assert.equal(validateReleaseChannel({ version: "0.1.20-rc.1", npmDistTag: "next" }).ok, true);
+  const stable = validateReleaseChannel({ version: "0.1.20", npmDistTag: "latest" });
+  assert.equal(stable.ok, true);
+  assert.equal(stable.release_channel, "stable");
+  assert.equal(stable.github_release_prerelease, false);
+  assert.equal(stable.docs_sync_expected, true);
+
+  const beta = validateReleaseChannel({ version: "0.1.20-beta.1", npmDistTag: "beta" });
+  assert.equal(beta.ok, true);
+  assert.equal(beta.release_channel, "prerelease");
+  assert.equal(beta.prerelease_identifier, "beta");
+  assert.equal(beta.expected_npm_dist_tag, "beta");
+  assert.equal(beta.github_release_prerelease, true);
+  assert.equal(beta.docs_sync_expected, false);
+
+  const releaseCandidate = validateReleaseChannel({
+    version: "0.1.20-rc.1",
+    npmDistTag: "next",
+  });
+  assert.equal(releaseCandidate.ok, true);
+  assert.equal(releaseCandidate.expected_npm_dist_tag, "next");
 
   const prereleaseOnLatest = validateReleaseChannel({
     version: "0.1.20-beta.1",
     npmDistTag: "latest",
   });
   assert.equal(prereleaseOnLatest.ok, false);
-  assert.match(prereleaseOnLatest.reason, /cannot use npm dist-tag 'latest'/);
+  assert.match(prereleaseOnLatest.reason, /must use npm dist-tag 'beta'/);
+
+  const betaOnAlpha = validateReleaseChannel({
+    version: "0.1.20-beta.1",
+    npmDistTag: "alpha",
+  });
+  assert.equal(betaOnAlpha.ok, false);
+  assert.match(betaOnAlpha.reason, /must use npm dist-tag 'beta'/);
 
   const stableOnBeta = validateReleaseChannel({ version: "0.1.20", npmDistTag: "beta" });
   assert.equal(stableOnBeta.ok, false);
@@ -65,4 +93,21 @@ test("requires exact publish confirmation before a real release", () => {
     }).ok,
     true,
   );
+});
+
+test("exports deterministic beta and Docs routing metadata for workflows", () => {
+  const output = join(mkdtempSync(join(tmpdir(), "openclaw-release-policy-")), "output");
+  main({
+    RELEASE_VERSION: "0.1.20-beta.1",
+    NPM_DIST_TAG: "beta",
+    DRY_RUN: "true",
+    PUBLISH_CONFIRMATION: "",
+    GITHUB_OUTPUT: output,
+  });
+  const values = readFileSync(output, "utf8");
+  assert.match(values, /^release_channel=prerelease$/m);
+  assert.match(values, /^prerelease_identifier=beta$/m);
+  assert.match(values, /^npm_dist_tag=beta$/m);
+  assert.match(values, /^github_release_prerelease=true$/m);
+  assert.match(values, /^docs_sync_expected=false$/m);
 });

--- a/.github/scripts/validate-release-source-version.mjs
+++ b/.github/scripts/validate-release-source-version.mjs
@@ -1,0 +1,102 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const RELEASE_VERSION_FILES = [
+  "package.json",
+  "openclaw.plugin.json",
+  "moltbot.plugin.json",
+  "clawdbot.plugin.json",
+];
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function readJsonAtRef(file, sourceRef) {
+  const raw =
+    sourceRef === "WORKTREE"
+      ? readFileSync(file, "utf8")
+      : execFileSync("git", ["show", `${sourceRef}:${file}`], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+  return JSON.parse(raw);
+}
+
+export function inspectReleaseSourceVersion({
+  expectedVersion,
+  sourceRef = "HEAD",
+  files = RELEASE_VERSION_FILES,
+} = {}) {
+  const expected = clean(expectedVersion);
+  const ref = clean(sourceRef) || "HEAD";
+  if (!expected) {
+    throw new Error("RELEASE_VERSION is required.");
+  }
+
+  const versions = [];
+  for (const file of files) {
+    try {
+      const value = readJsonAtRef(file, ref);
+      versions.push({
+        file,
+        version: clean(value?.version),
+        ok: clean(value?.version) === expected,
+        error: "",
+      });
+    } catch (error) {
+      versions.push({
+        file,
+        version: "",
+        ok: false,
+        error: clean(error?.message || error),
+      });
+    }
+  }
+
+  const mismatches = versions.filter((entry) => !entry.ok);
+  return {
+    ok: mismatches.length === 0,
+    expected_version: expected,
+    source_ref: ref,
+    versions,
+    mismatches,
+  };
+}
+
+export function formatReleaseSourceVersionError(report) {
+  const lines = [
+    `Release source ${report.source_ref} is not ready for version ${report.expected_version}.`,
+    "The publish workflow only consumes committed versions; it does not modify source files or create a version PR.",
+  ];
+  for (const entry of report.mismatches) {
+    const actual = entry.version || (entry.error ? "unreadable" : "missing");
+    lines.push(`- ${entry.file}: expected ${report.expected_version}, got ${actual}`);
+  }
+  lines.push(
+    "Update all four version files in a normal reviewed PR, merge it to main, then rerun the dry-run.",
+  );
+  return lines.join("\n");
+}
+
+export function run() {
+  const report = inspectReleaseSourceVersion({
+    expectedVersion: process.env.RELEASE_VERSION,
+    sourceRef: process.env.RELEASE_SOURCE_REF || "HEAD",
+  });
+  if (!report.ok) {
+    console.error(`::error::${formatReleaseSourceVersionError(report)}`);
+    process.exitCode = 1;
+    return report;
+  }
+
+  console.log(
+    `Validated ${report.expected_version} in ${RELEASE_VERSION_FILES.length} committed version files at ${report.source_ref}.`,
+  );
+  return report;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run();
+}

--- a/.github/scripts/validate-release-source-version.test.mjs
+++ b/.github/scripts/validate-release-source-version.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  formatReleaseSourceVersionError,
+  inspectReleaseSourceVersion,
+  RELEASE_VERSION_FILES,
+} from "./validate-release-source-version.mjs";
+
+function fixture(versions) {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-release-source-"));
+  for (const file of RELEASE_VERSION_FILES) {
+    writeFileSync(
+      join(root, file),
+      `${JSON.stringify({ version: versions[file] }, null, 2)}\n`,
+      "utf8",
+    );
+  }
+  return root;
+}
+
+function inspectWorktree(root, expectedVersion) {
+  const cwd = process.cwd();
+  process.chdir(root);
+  try {
+    return inspectReleaseSourceVersion({
+      expectedVersion,
+      sourceRef: "WORKTREE",
+    });
+  } finally {
+    process.chdir(cwd);
+  }
+}
+
+function git(root, args) {
+  return execFileSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+test("accepts a source only when all release version files match", () => {
+  const versions = Object.fromEntries(
+    RELEASE_VERSION_FILES.map((file) => [file, "0.1.20"]),
+  );
+  const report = inspectWorktree(fixture(versions), "0.1.20");
+  assert.equal(report.ok, true);
+  assert.equal(report.mismatches.length, 0);
+});
+
+test("reports every mismatched or missing version before publish", () => {
+  const root = fixture({
+    "package.json": "0.1.20",
+    "openclaw.plugin.json": "0.1.20-beta.0",
+    "moltbot.plugin.json": "",
+    "clawdbot.plugin.json": "0.1.19",
+  });
+  const report = inspectWorktree(root, "0.1.20");
+  assert.equal(report.ok, false);
+  assert.deepEqual(
+    report.mismatches.map((entry) => entry.file),
+    [
+      "openclaw.plugin.json",
+      "moltbot.plugin.json",
+      "clawdbot.plugin.json",
+    ],
+  );
+
+  const message = formatReleaseSourceVersionError(report);
+  assert.match(message, /does not modify source files or create a version PR/);
+  assert.match(message, /openclaw\.plugin\.json: expected 0\.1\.20, got 0\.1\.20-beta\.0/);
+  assert.match(message, /normal reviewed PR/);
+});
+
+test("reads the committed Git ref instead of uncommitted worktree changes", () => {
+  const versions = Object.fromEntries(
+    RELEASE_VERSION_FILES.map((file) => [file, "0.1.20-beta.1"]),
+  );
+  const root = fixture(versions);
+  git(root, ["init"]);
+  git(root, ["add", ...RELEASE_VERSION_FILES]);
+  git(root, [
+    "-c",
+    "user.name=release-test",
+    "-c",
+    "user.email=release-test@example.com",
+    "commit",
+    "-m",
+    "release fixture",
+  ]);
+  writeFileSync(
+    join(root, "package.json"),
+    `${JSON.stringify({ version: "0.1.20" }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const cwd = process.cwd();
+  process.chdir(root);
+  try {
+    const committed = inspectReleaseSourceVersion({
+      expectedVersion: "0.1.20-beta.1",
+      sourceRef: "HEAD",
+    });
+    const worktree = inspectReleaseSourceVersion({
+      expectedVersion: "0.1.20-beta.1",
+      sourceRef: "WORKTREE",
+    });
+    assert.equal(committed.ok, true);
+    assert.equal(worktree.ok, false);
+    assert.equal(worktree.mismatches[0].file, "package.json");
+  } finally {
+    process.chdir(cwd);
+  }
+});

--- a/.github/workflows/historical-dry-run.yml
+++ b/.github/workflows/historical-dry-run.yml
@@ -41,6 +41,7 @@ jobs:
       release_notes: ""
       dry_run: true
       recover_existing_npm_release: false
+      enforce_source_version: false
       artifact_name: openclaw-cloud-plugin-release-inspection-${{ matrix.version }}
       expected_previous_tag: ${{ matrix.expected_previous_tag }}
       expected_current_ref: ${{ matrix.expected_current_ref }}

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -17,6 +17,8 @@ on:
       - ".github/scripts/validate-github-release-inventory.test.mjs"
       - ".github/scripts/validate-release-confirmation.mjs"
       - ".github/scripts/validate-release-confirmation.test.mjs"
+      - ".github/scripts/validate-release-source-version.mjs"
+      - ".github/scripts/validate-release-source-version.test.mjs"
       - ".github/scripts/retry.sh"
       - "package.json"
       - "scripts/generate-telemetry-credentials.cjs"
@@ -30,18 +32,64 @@ permissions:
   contents: read
 
 jobs:
+  release_source:
+    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.source.outputs.version }}
+      npm_dist_tag: ${{ steps.source.outputs.npm_dist_tag }}
+      source_sha: ${{ steps.source.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Resolve committed release source
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          npm_dist_tag="latest"
+          if [[ "${version}" == *-* ]]; then
+            prerelease="${version#*-}"
+            npm_dist_tag="${prerelease%%.*}"
+            case "${npm_dist_tag}" in
+              alpha|beta|next) ;;
+              *) npm_dist_tag="next" ;;
+            esac
+          fi
+          RELEASE_VERSION="${version}" \
+            NPM_DIST_TAG="${npm_dist_tag}" \
+            DRY_RUN=true \
+            PUBLISH_CONFIRMATION="" \
+            node .github/scripts/validate-release-confirmation.mjs
+          {
+            echo "version=${version}"
+            echo "source_sha=$(git rev-parse HEAD)"
+          } >> "${GITHUB_OUTPUT}"
+
   dry-run:
+    needs: release_source
     if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
     permissions:
       contents: read
     uses: ./.github/workflows/release-dry-run.yml
     with:
-      version: "0.1.19"
-      tag: "latest"
-      git_ref: ""
+      version: ${{ needs.release_source.outputs.version }}
+      tag: ${{ needs.release_source.outputs.npm_dist_tag }}
+      git_ref: ${{ needs.release_source.outputs.source_sha }}
       release_notes: ""
       dry_run: true
       recover_existing_npm_release: false
+      enforce_source_version: true
+      expected_current_ref: ${{ needs.release_source.outputs.source_sha }}
     secrets:
       DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
       DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -17,6 +17,8 @@ on:
       - ".github/scripts/validate-github-release-inventory.test.mjs"
       - ".github/scripts/validate-release-confirmation.mjs"
       - ".github/scripts/validate-release-confirmation.test.mjs"
+      - ".github/scripts/validate-release-source-version.mjs"
+      - ".github/scripts/validate-release-source-version.test.mjs"
       - ".github/scripts/retry.sh"
       - "package.json"
       - "scripts/generate-telemetry-credentials.cjs"
@@ -87,3 +89,4 @@ jobs:
         <!-- doc-agent: source-id=openclaw-cloud-plugin -->
       dry_run: true
       recover_existing_npm_release: false
+      enforce_source_version: false

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: boolean
         default: false
+      enforce_source_version:
+        description: "Require the committed release source to already contain the requested version. Historical evidence replays may disable this."
+        required: false
+        type: boolean
+        default: true
       fault_case:
         description: "Release-note fault injection used by dry-run validation."
         required: false
@@ -94,6 +99,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Validate immutable dry-run inputs
+        id: release_policy
         shell: bash
         env:
           RELEASE_VERSION: ${{ inputs.version }}
@@ -102,6 +108,7 @@ jobs:
           RECOVER_EXISTING_NPM_RELEASE: ${{ inputs.recover_existing_npm_release }}
           RELEASE_FAULT_CASE: ${{ inputs.fault_case }}
           MANUAL_RELEASE_NOTES: ${{ inputs.release_notes }}
+          PUBLISH_CONFIRMATION: ""
         run: |
           set -euo pipefail
           if [ "${DRY_RUN}" != "true" ]; then
@@ -124,18 +131,11 @@ jobs:
             echo "::error::tag must be a valid npm dist-tag."
             exit 1
           fi
-          if [[ "${RELEASE_VERSION}" == *-* ]] && [ "${NPM_DIST_TAG}" = "latest" ]; then
-            echo "::error::Prerelease versions cannot use the latest npm dist-tag."
-            exit 1
-          fi
-          if [[ "${RELEASE_VERSION}" != *-* ]] && [ "${NPM_DIST_TAG}" != "latest" ]; then
-            echo "::error::Stable versions must use the latest npm dist-tag."
-            exit 1
-          fi
           if [ "${RELEASE_FAULT_CASE}" = "manual_notes_missing_payload" ] && [ -z "${MANUAL_RELEASE_NOTES}" ]; then
             echo "::error::manual_notes_missing_payload requires a manual release_notes fixture."
             exit 1
           fi
+          node .github/scripts/validate-release-confirmation.mjs
 
       - name: Resolve immutable evidence ref
         id: release_source
@@ -150,7 +150,10 @@ jobs:
             echo "::error::Evidence ref ${evidence_ref} is not an available commit."
             exit 1
           fi
-          echo "evidence_ref=${evidence_ref}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "evidence_ref=${evidence_ref}"
+            echo "source_commit=$(git rev-parse "${evidence_ref}^{commit}")"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Install dependencies
         shell: bash
@@ -167,14 +170,15 @@ jobs:
             echo "No plugin tests found; skipping."
           fi
 
-      - name: Bump package and plugin versions
+      - name: Validate committed release source version
+        if: ${{ inputs.enforce_source_version }}
         shell: bash
         env:
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_SOURCE_REF: ${{ steps.release_source.outputs.evidence_ref }}
         run: |
           set -euo pipefail
-          bash .github/scripts/retry.sh --label "bump package version" -- npm version "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
-          npm run sync-version
+          node .github/scripts/validate-release-source-version.mjs
 
       - name: Generate telemetry credentials
         shell: bash
@@ -184,18 +188,11 @@ jobs:
           MEMOS_ARMS_ENV: ${{ secrets.MEMOS_ARMS_ENV }}
         run: bash .github/scripts/retry.sh --label "generate telemetry credentials" -- node scripts/generate-telemetry-credentials.cjs
 
-      - name: Verify synchronized versions and package contents
+      - name: Verify package contents
+        if: ${{ inputs.enforce_source_version }}
         shell: bash
         run: |
           set -euo pipefail
-          node - <<'NODE'
-          const fs = require('node:fs');
-          const expected = require('./package.json').version;
-          for (const file of ['openclaw.plugin.json', 'moltbot.plugin.json', 'clawdbot.plugin.json']) {
-            const actual = JSON.parse(fs.readFileSync(file, 'utf8')).version;
-            if (actual !== expected) throw new Error(`${file}: expected ${expected}, got ${actual}`);
-          }
-          NODE
           bash .github/scripts/retry.sh --label "npm pack dry-run" -- bash -euo pipefail -c 'npm pack --dry-run --json > "${RUNNER_TEMP}/openclaw-cloud-plugin-pack.json"'
 
       - name: Draft and validate GitHub Release notes
@@ -227,10 +224,16 @@ jobs:
           DRAFT_USED: ${{ steps.release_notes.outputs.draft_used }}
           PREVIOUS_TAG: ${{ steps.release_notes.outputs.previous_tag }}
           CURRENT_REF: ${{ steps.release_notes.outputs.current_ref }}
+          SOURCE_COMMIT: ${{ steps.release_source.outputs.source_commit }}
+          RELEASE_CHANNEL: ${{ steps.release_policy.outputs.release_channel }}
+          NPM_DIST_TAG: ${{ steps.release_policy.outputs.npm_dist_tag }}
+          GITHUB_RELEASE_PRERELEASE: ${{ steps.release_policy.outputs.github_release_prerelease }}
+          DOCS_SYNC_EXPECTED: ${{ steps.release_policy.outputs.docs_sync_expected }}
           VALIDATION_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.validation_attempt_count }}
           REPAIR_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.repair_attempt_count }}
           EXPECTED_PREVIOUS_TAG: ${{ inputs.expected_previous_tag }}
           EXPECTED_CURRENT_REF: ${{ inputs.expected_current_ref }}
+          SOURCE_VERSION_GATE: ${{ inputs.enforce_source_version }}
         run: |
           set -euo pipefail
           inspection_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-inspection"
@@ -267,16 +270,48 @@ jobs:
             echo "::error::Expected current_ref=${EXPECTED_CURRENT_REF}, got ${CURRENT_REF:-n/a}."
             exit 1
           fi
+          github_release_prerelease_json="${GITHUB_RELEASE_PRERELEASE:-null}"
+          docs_sync_expected_json="${DOCS_SYNC_EXPECTED:-null}"
+          if [[ "${github_release_prerelease_json}" != "true" && "${github_release_prerelease_json}" != "false" ]]; then
+            github_release_prerelease_json=null
+          fi
+          if [[ "${docs_sync_expected_json}" != "true" && "${docs_sync_expected_json}" != "false" ]]; then
+            docs_sync_expected_json=null
+          fi
+          jq -n \
+            --arg version "${RELEASE_VERSION}" \
+            --arg source_commit "${SOURCE_COMMIT}" \
+            --arg evidence_ref "${CURRENT_REF:-}" \
+            --arg release_channel "${RELEASE_CHANNEL}" \
+            --arg npm_dist_tag "${NPM_DIST_TAG}" \
+            --argjson github_release_prerelease "${github_release_prerelease_json}" \
+            --argjson docs_sync_expected "${docs_sync_expected_json}" \
+            '{
+              version: $version,
+              source_commit: $source_commit,
+              evidence_ref: $evidence_ref,
+              release_channel: $release_channel,
+              npm_dist_tag: $npm_dist_tag,
+              github_release_prerelease: $github_release_prerelease,
+              docs_sync_expected: $docs_sync_expected
+            }' \
+            > "${inspection_dir}/release-source.json"
 
           {
             echo "# OpenClaw cloud plugin release inspection"
             echo
             echo "- draft_step_outcome: ${DRAFT_STEP_OUTCOME}"
             echo "- version: ${RELEASE_VERSION}"
+            echo "- release_channel: ${RELEASE_CHANNEL}"
+            echo "- npm_dist_tag: ${NPM_DIST_TAG}"
+            echo "- github_release_prerelease: ${GITHUB_RELEASE_PRERELEASE}"
+            echo "- docs_sync_expected: ${DOCS_SYNC_EXPECTED}"
             echo "- fault_case: ${FAULT_CASE}"
             echo "- draft_used: ${DRAFT_USED:-unknown}"
             echo "- previous_tag: ${PREVIOUS_TAG:-n/a}"
             echo "- current_ref: ${CURRENT_REF:-n/a}"
+            echo "- source_commit: ${SOURCE_COMMIT:-n/a}"
+            echo "- source_version_gate: ${SOURCE_VERSION_GATE}"
             echo "- validation_attempt_count: ${VALIDATION_ATTEMPT_COUNT:-n/a}"
             echo "- repair_attempt_count: ${REPAIR_ATTEMPT_COUNT:-n/a}"
             echo "- token_permissions: contents:read"
@@ -288,8 +323,13 @@ jobs:
             echo
             echo "- outcome: \`${DRAFT_STEP_OUTCOME}\`"
             echo "- version: \`${RELEASE_VERSION}\`"
+            echo "- release_channel: \`${RELEASE_CHANNEL}\`"
+            echo "- npm_dist_tag: \`${NPM_DIST_TAG}\`"
+            echo "- github_release_prerelease: \`${GITHUB_RELEASE_PRERELEASE}\`"
+            echo "- docs_sync_expected: \`${DOCS_SYNC_EXPECTED}\`"
             echo "- previous_tag: \`${PREVIOUS_TAG:-n/a}\`"
             echo "- current_ref: \`${CURRENT_REF:-n/a}\`"
+            echo "- source_commit: \`${SOURCE_COMMIT:-n/a}\`"
             echo "- validation_attempt_count: \`${VALIDATION_ATTEMPT_COUNT:-n/a}\`"
             echo "- repair_attempt_count: \`${REPAIR_ATTEMPT_COUNT:-n/a}\`"
             echo "- permissions: \`contents: read\`"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,15 @@ on:
       tag:
         description: "npm dist-tag (latest for production, beta/next/alpha for testing)"
         required: true
+        type: choice
         default: "latest"
+        options:
+          - latest
+          - beta
+          - next
+          - alpha
       git_ref:
-        description: "Git ref to build from. Leave blank to use the branch selected above."
+        description: "Dry-run: leave blank for main. Real publish: exact 40-character source_commit approved in the dry-run."
         required: false
         default: ""
       release_notes:
@@ -53,13 +59,34 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Validate immutable publish ref
+        if: ${{ inputs.dry_run != true }}
+        shell: bash
+        env:
+          RELEASE_GIT_REF: ${{ inputs.git_ref }}
+          RECOVER_EXISTING_NPM_RELEASE: ${{ inputs.recover_existing_npm_release }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+            echo "::error::Real releases must be dispatched with Use workflow from=${DEFAULT_BRANCH}; got ${GITHUB_REF}."
+            exit 1
+          fi
+          if [ "${RECOVER_EXISTING_NPM_RELEASE}" != "true" ] && ! [[ "${RELEASE_GIT_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::Normal real releases require git_ref to be the exact 40-character source_commit approved in the dry-run."
+            exit 1
+          fi
+          if [ "${RECOVER_EXISTING_NPM_RELEASE}" = "true" ] && [ -n "${RELEASE_GIT_REF//[[:space:]]/}" ] && [ "${RELEASE_GIT_REF}" != "${DEFAULT_BRANCH}" ] && [ "${RELEASE_GIT_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+            echo "::error::Recovery runs use npm gitHead as the immutable source; leave git_ref blank or set it to ${DEFAULT_BRANCH}."
+            exit 1
+          fi
+
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.git_ref || github.ref }}
@@ -72,6 +99,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Validate release inputs
+        id: release_policy
         shell: bash
         env:
           RELEASE_VERSION: ${{ inputs.version }}
@@ -80,6 +108,7 @@ jobs:
           PUBLISH_CONFIRMATION: ${{ inputs.publish_confirmation }}
           RELEASE_FAULT_CASE: ${{ inputs.fault_case }}
           RELEASE_GIT_REF: ${{ inputs.git_ref }}
+          RECOVER_EXISTING_NPM_RELEASE: ${{ inputs.recover_existing_npm_release }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
@@ -107,9 +136,23 @@ jobs:
             echo "::error::Real releases must be dispatched from the protected default branch ${DEFAULT_BRANCH}; got ${GITHUB_REF}."
             exit 1
           fi
-          if [ "${DRY_RUN}" != "true" ] && [ -n "${RELEASE_GIT_REF//[[:space:]]/}" ] && [ "${RELEASE_GIT_REF}" != "${DEFAULT_BRANCH}" ] && [ "${RELEASE_GIT_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
-            echo "::error::Real releases cannot override git_ref away from the protected default branch ${DEFAULT_BRANCH}."
-            exit 1
+          if [ "${DRY_RUN}" != "true" ]; then
+            if [ "${RECOVER_EXISTING_NPM_RELEASE}" != "true" ] && ! [[ "${RELEASE_GIT_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "::error::Normal real releases require git_ref to be the exact 40-character source_commit approved in the dry-run."
+              exit 1
+            fi
+            if [ "${RECOVER_EXISTING_NPM_RELEASE}" = "true" ] && [ -n "${RELEASE_GIT_REF//[[:space:]]/}" ] && [ "${RELEASE_GIT_REF}" != "${DEFAULT_BRANCH}" ] && [ "${RELEASE_GIT_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+              echo "::error::Recovery runs use npm gitHead as the immutable source and cannot override git_ref away from ${DEFAULT_BRANCH}."
+              exit 1
+            fi
+          fi
+          if [ "${DRY_RUN}" != "true" ] && [ "${RECOVER_EXISTING_NPM_RELEASE}" != "true" ]; then
+            approved_commit="$(git rev-parse "${RELEASE_GIT_REF}^{commit}")"
+            checked_out_commit="$(git rev-parse HEAD)"
+            if [ "${checked_out_commit}" != "${approved_commit}" ]; then
+              echo "::error::Checked-out commit ${checked_out_commit} does not match approved dry-run commit ${approved_commit}."
+              exit 1
+            fi
           fi
           node .github/scripts/validate-release-confirmation.mjs
 
@@ -213,11 +256,14 @@ jobs:
           elif git rev-parse --verify --quiet "${release_tag}^{commit}" >/dev/null; then
             echo "::error::Tag ${release_tag} exists while ${PACKAGE_NAME}@${RELEASE_VERSION} is absent; refusing inconsistent release metadata."
             exit 1
+          else
+            evidence_ref="HEAD"
           fi
 
           {
             echo "evidence_ref=${evidence_ref}"
             echo "npm_git_head=${npm_git_head}"
+            echo "source_commit=$(git rev-parse "${evidence_ref}^{commit}")"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Install dependencies
@@ -235,14 +281,14 @@ jobs:
             echo "No plugin tests found; skipping."
           fi
 
-      - name: Bump package and plugin versions
+      - name: Validate committed release source version
         shell: bash
         env:
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_SOURCE_REF: ${{ steps.release_source.outputs.evidence_ref }}
         run: |
           set -euo pipefail
-          bash .github/scripts/retry.sh --label "bump package version" -- npm version "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
-          npm run sync-version
+          node .github/scripts/validate-release-source-version.mjs
 
       - name: Generate telemetry credentials
         shell: bash
@@ -252,18 +298,10 @@ jobs:
           MEMOS_ARMS_ENV: ${{ secrets.MEMOS_ARMS_ENV }}
         run: bash .github/scripts/retry.sh --label "generate telemetry credentials" -- node scripts/generate-telemetry-credentials.cjs
 
-      - name: Verify synchronized versions and package contents
+      - name: Verify package contents
         shell: bash
         run: |
           set -euo pipefail
-          node - <<'NODE'
-          const fs = require('node:fs');
-          const expected = require('./package.json').version;
-          for (const file of ['openclaw.plugin.json', 'moltbot.plugin.json', 'clawdbot.plugin.json']) {
-            const actual = JSON.parse(fs.readFileSync(file, 'utf8')).version;
-            if (actual !== expected) throw new Error(`${file}: expected ${expected}, got ${actual}`);
-          }
-          NODE
           bash .github/scripts/retry.sh --label "npm pack dry-run" -- bash -euo pipefail -c 'npm pack --dry-run --json > "${RUNNER_TEMP}/openclaw-cloud-plugin-pack.json"'
 
       - name: Draft GitHub Release notes
@@ -297,6 +335,11 @@ jobs:
           PREVIOUS_TAG: ${{ steps.release_notes.outputs.previous_tag }}
           CURRENT_TAG: ${{ steps.release_notes.outputs.current_tag }}
           CURRENT_REF: ${{ steps.release_notes.outputs.current_ref }}
+          SOURCE_COMMIT: ${{ steps.release_source.outputs.source_commit }}
+          RELEASE_CHANNEL: ${{ steps.release_policy.outputs.release_channel }}
+          NPM_DIST_TAG: ${{ steps.release_policy.outputs.npm_dist_tag }}
+          GITHUB_RELEASE_PRERELEASE: ${{ steps.release_policy.outputs.github_release_prerelease }}
+          DOCS_SYNC_EXPECTED: ${{ steps.release_policy.outputs.docs_sync_expected }}
           DRAFT_CONFIDENCE: ${{ steps.release_notes.outputs.draft_confidence }}
           MISSING_REQUIRED_COUNT: ${{ steps.release_notes.outputs.missing_required_count }}
           VALIDATION_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.validation_attempt_count }}
@@ -347,6 +390,32 @@ jobs:
             echo "::error::quality-report.json was not generated."
             exit 1
           fi
+          github_release_prerelease_json="${GITHUB_RELEASE_PRERELEASE:-null}"
+          docs_sync_expected_json="${DOCS_SYNC_EXPECTED:-null}"
+          if [[ "${github_release_prerelease_json}" != "true" && "${github_release_prerelease_json}" != "false" ]]; then
+            github_release_prerelease_json=null
+          fi
+          if [[ "${docs_sync_expected_json}" != "true" && "${docs_sync_expected_json}" != "false" ]]; then
+            docs_sync_expected_json=null
+          fi
+          jq -n \
+            --arg version "${RELEASE_VERSION}" \
+            --arg source_commit "${SOURCE_COMMIT}" \
+            --arg evidence_ref "${CURRENT_REF:-}" \
+            --arg release_channel "${RELEASE_CHANNEL}" \
+            --arg npm_dist_tag "${NPM_DIST_TAG}" \
+            --argjson github_release_prerelease "${github_release_prerelease_json}" \
+            --argjson docs_sync_expected "${docs_sync_expected_json}" \
+            '{
+              version: $version,
+              source_commit: $source_commit,
+              evidence_ref: $evidence_ref,
+              release_channel: $release_channel,
+              npm_dist_tag: $npm_dist_tag,
+              github_release_prerelease: $github_release_prerelease,
+              docs_sync_expected: $docs_sync_expected
+            }' \
+            > "${inspection_dir}/release-source.json"
 
           {
             echo "# OpenClaw cloud plugin release inspection"
@@ -354,11 +423,16 @@ jobs:
             echo "- draft_step_outcome: ${DRAFT_STEP_OUTCOME}"
             echo "- dry_run: ${DRY_RUN}"
             echo "- version: ${RELEASE_VERSION}"
+            echo "- release_channel: ${RELEASE_CHANNEL}"
+            echo "- npm_dist_tag: ${NPM_DIST_TAG}"
+            echo "- github_release_prerelease: ${GITHUB_RELEASE_PRERELEASE}"
+            echo "- docs_sync_expected: ${DOCS_SYNC_EXPECTED}"
             echo "- fault_case: ${FAULT_CASE}"
             echo "- draft_used: ${DRAFT_USED:-unknown}"
             echo "- previous_tag: ${PREVIOUS_TAG:-n/a}"
             echo "- current_tag: ${CURRENT_TAG:-n/a}"
             echo "- current_ref: ${CURRENT_REF:-n/a}"
+            echo "- source_commit: ${SOURCE_COMMIT:-n/a}"
             echo "- draft_confidence: ${DRAFT_CONFIDENCE:-n/a}"
             echo "- missing_required_count: ${MISSING_REQUIRED_COUNT:-n/a}"
             echo "- validation_attempt_count: ${VALIDATION_ATTEMPT_COUNT:-n/a}"
@@ -385,6 +459,7 @@ jobs:
             if [ -f "${inspection_dir}/quality-report.json" ]; then
               echo "- quality-report.json"
             fi
+            echo "- release-source.json"
           } > "${inspection_dir}/README.md"
 
           {
@@ -392,11 +467,16 @@ jobs:
             echo
             echo "- draft_step_outcome: \`${DRAFT_STEP_OUTCOME}\`"
             echo "- dry_run: \`${DRY_RUN}\`"
+            echo "- release_channel: \`${RELEASE_CHANNEL}\`"
+            echo "- npm_dist_tag: \`${NPM_DIST_TAG}\`"
+            echo "- github_release_prerelease: \`${GITHUB_RELEASE_PRERELEASE}\`"
+            echo "- docs_sync_expected: \`${DOCS_SYNC_EXPECTED}\`"
             echo "- fault_case: \`${FAULT_CASE}\`"
             echo "- draft_used: \`${DRAFT_USED:-unknown}\`"
             echo "- previous_tag: \`${PREVIOUS_TAG:-n/a}\`"
             echo "- current_tag: \`${CURRENT_TAG:-n/a}\`"
             echo "- current_ref: \`${CURRENT_REF:-n/a}\`"
+            echo "- source_commit: \`${SOURCE_COMMIT:-n/a}\`"
             echo "- draft_confidence: \`${DRAFT_CONFIDENCE:-n/a}\`"
             echo "- missing_required_count: \`${MISSING_REQUIRED_COUNT:-n/a}\`"
             echo "- validation_attempt_count: \`${VALIDATION_ATTEMPT_COUNT:-n/a}\`"
@@ -422,7 +502,7 @@ jobs:
       - name: Stop before publish in dry run
         if: ${{ inputs.dry_run == true }}
         run: |
-          echo "::notice::dry_run=true; skipped npm publish, tag, GitHub Release, and release PR."
+          echo "::notice::dry_run=true; skipped npm publish, tag, and GitHub Release."
 
       - name: Publish to npm
         id: publish_npm
@@ -434,20 +514,16 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
           RELEASE_TAG: v${{ inputs.version }}
           NPM_DIST_TAG: ${{ inputs.tag }}
+          EXPECTED_RELEASE_PRERELEASE: ${{ steps.release_policy.outputs.github_release_prerelease }}
           RECOVER_EXISTING_NPM_RELEASE: ${{ inputs.recover_existing_npm_release }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
           release_tag="v${RELEASE_VERSION#v}"
-          release_branch="release/openclaw-cloud-plugin-${release_tag}"
-          expected_release_prerelease=false
-          if [[ "${RELEASE_VERSION}" == *-* || "${NPM_DIST_TAG}" != "latest" ]]; then
-            expected_release_prerelease=true
-          fi
+          expected_release_prerelease="${EXPECTED_RELEASE_PRERELEASE}"
           report_exhausted_failure() {
             local phase="$1"
             local attempt_dir="$2"
@@ -629,20 +705,11 @@ jobs:
             release_exists=true
           fi
 
-          create_version_pr=false
-          existing_release_branch_sha="$(remote_branch_sha "${release_branch}")"
           if npm_version_exists; then
             release_commit_sha="$(npm_release_git_head)"
             ensure_commit_available "${release_commit_sha}"
             validate_release_commit_versions "${release_commit_sha}"
 
-            if [ -n "${existing_release_branch_sha}" ]; then
-              if [ "${existing_release_branch_sha}" != "${release_commit_sha}" ]; then
-                echo "::error::Release branch ${release_branch} points to ${existing_release_branch_sha}, but npm records gitHead ${release_commit_sha}."
-                exit 1
-              fi
-              create_version_pr=true
-            fi
             if [ "${tag_exists}" = "true" ] && [ "${tag_commit}" != "${release_commit_sha}" ]; then
               echo "::error::Tag ${release_tag} points to ${tag_commit}, but npm ${PACKAGE_NAME}@${RELEASE_VERSION} records gitHead ${release_commit_sha}."
               exit 1
@@ -665,41 +732,28 @@ jobs:
               exit 1
             fi
           else
+            if [ "${RECOVER_EXISTING_NPM_RELEASE}" = "true" ]; then
+              echo "::error::Recovery requires ${PACKAGE_NAME}@${RELEASE_VERSION} to already exist on npm. Refusing to turn metadata recovery into a first publish."
+              exit 1
+            fi
             if [ "${tag_exists}" = "true" ] || [ "${release_exists}" = "true" ]; then
               echo "::error::Refusing to publish ${PACKAGE_NAME}@${RELEASE_VERSION}: GitHub tag/Release metadata already exists while npm does not."
               exit 1
             fi
 
             source_commit_sha="$(git rev-parse HEAD)"
-            if [ -n "${existing_release_branch_sha}" ]; then
-              ensure_commit_available "${existing_release_branch_sha}"
-              if [ "${existing_release_branch_sha}" != "${source_commit_sha}" ]; then
-                release_parent_sha="$(git rev-parse "${existing_release_branch_sha}^")"
-                if [ "${release_parent_sha}" != "${source_commit_sha}" ]; then
-                  echo "::error::Release branch ${release_branch} is based on ${release_parent_sha}, expected current source ${source_commit_sha}."
-                  exit 1
-                fi
-              fi
-              validate_release_commit_versions "${existing_release_branch_sha}"
-              git checkout --detach --force "${existing_release_branch_sha}"
-              release_commit_sha="${existing_release_branch_sha}"
-              echo "Reusing durable release commit ${release_commit_sha} after an earlier interrupted publish."
-            else
-              git add package.json openclaw.plugin.json moltbot.plugin.json clawdbot.plugin.json
-              if ! git diff --staged --quiet; then
-                git commit -m "release: @memtensor/memos-cloud-openclaw-plugin ${release_tag}"
-              fi
-              release_commit_sha="$(git rev-parse HEAD)"
-              validate_release_commit_versions "${release_commit_sha}"
-              durable_branch_attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-durable-branch-attempts"
-              if ! RETRY_ATTEMPT_DIR="${durable_branch_attempt_dir}" \
-                bash .github/scripts/retry.sh --label "push durable release branch" -- \
-                  git push origin "${release_commit_sha}:refs/heads/${release_branch}"; then
-                report_exhausted_failure "github-durable-release-branch-push" "${durable_branch_attempt_dir}"
-                exit 1
-              fi
+            remote_default_sha="$(remote_branch_sha "${DEFAULT_BRANCH}")"
+            if [ -z "${remote_default_sha}" ]; then
+              echo "::error::Could not resolve the protected default branch ${DEFAULT_BRANCH}."
+              exit 1
             fi
-            create_version_pr=true
+            if [ "${remote_default_sha}" != "${source_commit_sha}" ]; then
+              echo "::error::The checked-out release source ${source_commit_sha} is no longer the head of ${DEFAULT_BRANCH} (${remote_default_sha}). Rerun the workflow from the latest main commit."
+              exit 1
+            fi
+            release_commit_sha="${source_commit_sha}"
+            validate_release_commit_versions "${release_commit_sha}"
+            echo "Publishing the already-reviewed ${DEFAULT_BRANCH} commit ${release_commit_sha}; no source files or release branch will be created."
 
             attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-npm-publish-attempts"
             mkdir -p "${attempt_dir}"
@@ -753,21 +807,17 @@ jobs:
             fi
           fi
 
-          {
-            echo "release_commit_sha=${release_commit_sha}"
-            echo "create_version_pr=${create_version_pr}"
-          } >> "${GITHUB_OUTPUT}"
+          echo "release_commit_sha=${release_commit_sha}" >> "${GITHUB_OUTPUT}"
 
-      - name: Create release tag, GitHub Release, and version PR
+      - name: Create release tag and GitHub Release
         if: ${{ inputs.dry_run != true }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ inputs.version }}
           NPM_DIST_TAG: ${{ inputs.tag }}
+          EXPECTED_RELEASE_PRERELEASE: ${{ steps.release_policy.outputs.github_release_prerelease }}
           RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
           RELEASE_COMMIT_SHA: ${{ steps.publish_npm.outputs.release_commit_sha }}
-          CREATE_VERSION_PR: ${{ steps.publish_npm.outputs.create_version_pr }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
         run: |
@@ -789,12 +839,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           release_tag="v${RELEASE_VERSION#v}"
-          release_branch="release/openclaw-cloud-plugin-${release_tag}"
-          release_title="release: @memtensor/memos-cloud-openclaw-plugin ${release_tag}"
-          expected_release_prerelease=false
-          if [[ "${RELEASE_VERSION}" == *-* || "${NPM_DIST_TAG}" != "latest" ]]; then
-            expected_release_prerelease=true
-          fi
+          expected_release_prerelease="${EXPECTED_RELEASE_PRERELEASE}"
           report_exhausted_failure() {
             local phase="$1"
             local attempt_dir="$2"
@@ -803,28 +848,6 @@ jobs:
               RELEASE_TAG="${release_tag}" \
               node .github/scripts/draft-cloud-plugin-release-notes.mjs \
               || echo "::warning::Failed to report exhausted ${phase} attempts."
-          }
-          remote_branch_sha() {
-            local branch="$1"
-            local attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-remote-branch-attempts"
-            mkdir -p "${attempt_dir}"
-            for attempt in 1 2 3; do
-              set +e
-              git ls-remote --heads origin "${branch}" >"${attempt_dir}/${attempt}.log" 2>&1
-              status=$?
-              set -e
-              if [ "${status}" = 0 ]; then
-                awk '{print $1}' "${attempt_dir}/${attempt}.log"
-                return 0
-              fi
-              sed -n '1,120p' "${attempt_dir}/${attempt}.log" >&2
-              if [ "${attempt}" = 3 ]; then
-                report_exhausted_failure "github-release-branch-lookup" "${attempt_dir}"
-                echo "::error::Failed to check remote branch ${branch} after three attempts."
-                exit "${status}"
-              fi
-              sleep "$((attempt * 5))"
-            done
           }
           remote_tag_exists() {
             local tag="$1"
@@ -971,42 +994,6 @@ jobs:
             echo "::error::Failed to create and verify GitHub Release ${release_tag} after three attempts."
             exit 1
           }
-          create_pr_if_missing() {
-            local attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-pr-attempts"
-            mkdir -p "${attempt_dir}"
-            if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-              echo "Release PR already exists for ${release_branch}."
-              return 0
-            fi
-            for attempt in 1 2 3; do
-              set +e
-              gh pr create \
-                --repo "${GITHUB_REPOSITORY}" \
-                --base "${DEFAULT_BRANCH}" \
-                --head "${release_branch}" \
-                --title "${release_title}" \
-                --body "Bumps package.json and plugin manifests for the published npm release ${release_tag}." \
-                >"${attempt_dir}/${attempt}.log" 2>&1
-              status=$?
-              set -e
-              if [ "${status}" = 0 ]; then
-                sed -n '1,80p' "${attempt_dir}/${attempt}.log"
-                return 0
-              fi
-              sed -n '1,120p' "${attempt_dir}/${attempt}.log" >&2
-              if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-                echo "Release PR exists after a failed create response; treating as success."
-                return 0
-              fi
-              if [ "${attempt}" = 3 ]; then
-                report_exhausted_failure "github-release-pr-create" "${attempt_dir}"
-                echo "::error::Failed to create release PR automatically after three attempts. Rerun this workflow to reconcile the durable release branch, or open a PR from ${release_branch} to ${DEFAULT_BRANCH}."
-                return "${status}"
-              fi
-              sleep "$((attempt * 5))"
-            done
-          }
-
           refresh_release_inventory
           set +e
           release_inventory_report="$(inspect_release_inventory false)"
@@ -1041,29 +1028,3 @@ jobs:
           fi
 
           create_release_if_missing
-
-          remote_branch_sha="$(remote_branch_sha "${release_branch}")"
-          should_create_version_pr=false
-          if [ -n "${remote_branch_sha}" ]; then
-            if [ "${remote_branch_sha}" != "${RELEASE_COMMIT_SHA}" ]; then
-              echo "::error::Release branch ${release_branch} already exists at a different commit; refusing to overwrite it."
-              exit 1
-            fi
-            echo "Release branch ${release_branch} already points at this commit."
-            should_create_version_pr=true
-          elif [ "${CREATE_VERSION_PR}" = "true" ]; then
-            branch_attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-release-branch-push-attempts"
-            if ! RETRY_ATTEMPT_DIR="${branch_attempt_dir}" \
-              bash .github/scripts/retry.sh --label "push release branch" -- \
-                git push origin "${RELEASE_COMMIT_SHA}:refs/heads/${release_branch}"; then
-              report_exhausted_failure "github-release-branch-push" "${branch_attempt_dir}"
-              exit 1
-            fi
-            should_create_version_pr=true
-          fi
-
-          if [ "${should_create_version_pr}" = "true" ]; then
-            create_pr_if_missing
-          else
-            echo "Metadata recovery used npm gitHead ${RELEASE_COMMIT_SHA}; no durable release branch exists, so no version PR was created."
-          fi

--- a/.github/workflows/workflow-contract-lint.yml
+++ b/.github/workflows/workflow-contract-lint.yml
@@ -9,6 +9,10 @@ on:
       - ".github/workflows/**"
       - ".github/scripts/validate-github-release-inventory.mjs"
       - ".github/scripts/validate-github-release-inventory.test.mjs"
+      - ".github/scripts/validate-release-confirmation.mjs"
+      - ".github/scripts/validate-release-confirmation.test.mjs"
+      - ".github/scripts/validate-release-source-version.mjs"
+      - ".github/scripts/validate-release-source-version.test.mjs"
 
 permissions:
   contents: read
@@ -54,4 +58,4 @@ jobs:
 
       - name: Validate reusable workflow boundaries
         shell: bash
-        run: node --test .github/scripts/validate-github-release-inventory.test.mjs
+        run: node --test .github/scripts/validate-github-release-inventory.test.mjs .github/scripts/validate-release-confirmation.test.mjs .github/scripts/validate-release-source-version.test.mjs


### PR DESCRIPTION
## Summary

- publish only versions already reviewed and committed on `main`; the workflow no longer edits source versions, pushes a release branch, or creates a version writeback PR
- validate `package.json`, `openclaw.plugin.json`, `moltbot.plugin.json`, and `clawdbot.plugin.json` at the immutable release ref before any publish
- record the Dry-run `source_commit`, require the exact 40-character commit for a real publish, and stop before npm if `main` moved after approval
- route stable and prerelease versions deterministically:
  - `X.Y.Z` + `latest` -> npm stable + published GitHub Release + formal Docs sync
  - `X.Y.Z-beta.N` + `beta` (or `alpha`/`next`) -> npm preview + GitHub Prerelease; 106 skips the formal Docs PR
- keep metadata recovery pinned to npm `gitHead`, and fail closed if recovery is requested for a version that does not already exist on npm
- remove `pull-requests: write`; this flow does not require **Allow GitHub Actions to create and approve pull requests**

## Release-owner workflow after merge

1. Update all four version files in a normal reviewed PR and merge it to `main`.
2. Run **OpenClaw Cloud Plugin — Publish & Release** with `dry_run=true`.
3. Review the inspection artifact and copy `release-source.json.source_commit`.
4. Run the same workflow with `dry_run=false`, the same version/channel, the exact `source_commit`, and `PUBLISH v<VERSION>`.
5. For stable releases, review the MemOS-Docs PR created by 106. Prereleases intentionally stop before Docs/pre/gray.

## Validation

- `npm test` — 120/120 passed
- release policy/source/inventory contract tests — 15/15 passed
- `actionlint` — passed
- all workflow YAML files parsed successfully
- `git diff --check` — passed
- `npm pack --dry-run --json` — passed, 17 package files
- committed source gate:
  - `0.1.20-beta.0` against current `HEAD` — passed
  - `0.1.20` against current `HEAD` — correctly failed and reported all four mismatched files
- 106 `scripts/test_release_sync.py` smoke tests — passed, including `prerelease -> skip_prerelease` and `would_create_docs_pr=false`

No npm publish, tag, GitHub Release, or production deployment was triggered while preparing this PR.
