### PR TITLE
fix: migrate recall to before_prompt_build

### DIFF
--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -597,6 +597,16 @@ function knownReleaseItemsForItem(item, index, { allowSplit = true } = {}) {
   const systemPromptPattern =
     /system prompt detection and handling|scheduled task|scheduled reminder|background command|system event|isforcedsystemmessage|system prompt/;
 
+  if (/remove.*before_agent_start|retired.*before_agent_start|use before_prompt_build.*recall hook/.test(subjectBlob)) {
+    return [
+      rewrite(
+        "Fixed",
+        "**Recall Hook 对齐当前 OpenClaw**：统一使用 `before_prompt_build` 注入召回上下文，并移除已废弃的 `before_agent_start` 回退。",
+        "**Recall Hook aligned with current OpenClaw**: Uses `before_prompt_build` for recalled context and removes the retired `before_agent_start` fallback.",
+      ),
+    ];
+  }
+
   if (/recall hook registration.*before_prompt_build|before_prompt_build.*newer openclaw|version compatibility/.test(subjectBlob)) {
     return [
       rewrite(

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -510,6 +510,46 @@ test("fails closed when a draft contains only release-automation evidence", () =
   assert.ok(processed.validation_report.issues.some((issue) => issue.kind === "empty_release_items"));
 });
 
+test("describes removal of the retired recall hook fallback", () => {
+  const commit = {
+    sha: "abc1234000000000000000000000000000000000",
+    short_sha: "abc1234",
+    subject: "fix: use before_prompt_build recall hook",
+  };
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Fixed",
+          text_cn: "**召回 Hook 修复**：更新 OpenClaw 召回 Hook。",
+          text_en: "**Recall hook fix**: Updates the OpenClaw recall hook.",
+          source_refs: ["abc1234"],
+        },
+      ],
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits: [commit],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Fixed",
+            source_refs: ["abc1234"],
+            subject: commit.subject,
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.match(processed.release_notes_markdown, /Recall Hook 对齐当前 OpenClaw/);
+  assert.match(processed.release_notes_markdown, /removes the retired `before_agent_start` fallback/);
+});
+
 test("splits collapsed multi-ref historical drafts into docs-ready cloud plugin topics", () => {
   const commits = [
     {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Official plugin maintained by MemTensor.
 A minimal OpenClaw lifecycle plugin that **recalls** memories from MemOS Cloud before each run and **adds** new messages to MemOS Cloud after each run.
 
 ## Features
-- **Recall**: `before_prompt_build` (`before_agent_start` on older OpenClaw hosts) → `/search/memory`
+- **Recall**: `before_prompt_build` → `/search/memory`
 - **Add**: `agent_end` → `/add/message`
 - **Config UI**: starting the gateway also starts a local plugin config page for editing `plugins.entries.memos-cloud-openclaw-plugin.config`
 - Uses **Token** auth (`Authorization: Token <MEMOS_API_KEY>`)
@@ -164,7 +164,7 @@ In `plugins.entries.memos-cloud-openclaw-plugin.config`:
 ```
 
 ## How it Works
-- **Recall** (`before_prompt_build`; falls back to `before_agent_start` on older OpenClaw hosts)
+- **Recall** (`before_prompt_build`)
   - Builds a `/search/memory` request using `user_id`, `query` (= prompt + optional prefix), and optional filters.
   - Default **global recall**: when `recallGlobal=true`, it does **not** pass `conversation_id`.
   - Optional second-pass filtering: if `recallFilterEnabled=true`, candidates are sent to your configured model and only returned `keep` items are injected.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -7,7 +7,7 @@
 - **添加记忆**：在每轮对话结束后把消息写回 MemOS Cloud
 
 ## 功能
-- **Recall**：`before_prompt_build`（旧版 OpenClaw 回退到 `before_agent_start`）→ `/search/memory`
+- **Recall**：`before_prompt_build` → `/search/memory`
 - **Add**：`agent_end` → `/add/message`
 - **Config UI**：启动 gateway 时同时启动本地插件配置页面，用来编辑 `plugins.entries.memos-cloud-openclaw-plugin.config`
 - 使用 **Token** 认证（`Authorization: Token <MEMOS_API_KEY>`）
@@ -164,7 +164,7 @@ MEMOS_API_KEY=YOUR_TOKEN
 ```
 
 ## 工作原理
-### 1) 召回（新版 OpenClaw 使用 `before_prompt_build`；旧版回退到 `before_agent_start`）
+### 1) 召回（`before_prompt_build`）
 - 组装 `/search/memory` 请求
   - `user_id`、`query`（= prompt + 可选前缀）
   - 默认**全局召回**：`recallGlobal=true` 时不传 `conversation_id`

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ import { startUpdateChecker } from "./lib/check-update.js";
 import {
   closeConfigUiService,
   compareVersionStrings,
+  detectRuntimeProfile,
   detectHostVersion,
   ensureConfigUiService,
   ensurePluginHookPolicy,
@@ -718,6 +719,7 @@ export default {
 
     // Detect the host CLI version once so every hook registration branch can reference it.
     const hostVersion = detectHostVersion();
+    const hostProfile = detectRuntimeProfile();
 
     // Side effects below are only meaningful when the host CLI was actually
     // launched to run the gateway (`openclaw gateway run|start|restart`).
@@ -843,19 +845,12 @@ export default {
       }
     };
 
-    // Recall mutates prompt context only, so the phase-specific replacement for
-    // legacy before_agent_start is before_prompt_build. Do not register both on
-    // new hosts, otherwise the same memory block can be injected twice.
-    const PROMPT_BUILD_HOOK_MIN_VERSION = "2026.5.7";
-    const usesBeforePromptBuild =
-      hostVersion !== null &&
-      compareVersionStrings(hostVersion, PROMPT_BUILD_HOOK_MIN_VERSION) >= 0;
-
-    if (usesBeforePromptBuild) {
-      api.on("before_prompt_build", runRecall);
-    } else {
-      api.on("before_agent_start", runRecall);
-    }
+    // Current OpenClaw hosts use the prompt-build phase. The package still
+    // advertises Moltbot and ClawDBot entrypoints, which only expose the legacy hook.
+    api.on(
+      hostProfile.id === "openclaw" ? "before_prompt_build" : "before_agent_start",
+      runRecall,
+    );
 
     api.on("agent_end", async (event, ctx) => {
       // Skip system events: heartbeat and commands

--- a/lib/config-ui-server.js
+++ b/lib/config-ui-server.js
@@ -52,7 +52,7 @@ const FIELD_DEFINITIONS = [
   { key: "resetOnNew", group: "session", type: "boolean", label: "Reset On /new", description: "Requires hooks.internal.enabled when counter suffix mode is used." },
   { key: "queryPrefix", group: "session", type: "textarea", rows: 4, label: "Query Prefix", description: "Extra text prepended to query before retrieval.", placeholder: "important user context preferences decisions " },
   { key: "maxQueryChars", group: "session", type: "integer", label: "Max Query Chars", description: "Limit the query text length before sending recall search.", placeholder: "0" },
-  { key: "recallEnabled", group: "session", type: "boolean", label: "Recall Enabled", description: "Enable before_agent_start memory recall." },
+  { key: "recallEnabled", group: "session", type: "boolean", label: "Recall Enabled", description: "Enable memory recall before prompt construction." },
   { key: "recallGlobal", group: "session", type: "boolean", label: "Global Recall", description: "When enabled, query is sent without conversation_id, so current-session weighting is not emphasized." },
   { key: "maxItemChars", group: "session", type: "integer", label: "Max Item Chars", description: "Maximum characters kept when injecting each recalled memory item into context.", placeholder: "8000" },
   { key: "memoryLimitNumber", group: "session", type: "integer", label: "Memory Limit", description: "Maximum number of recalled memories. Default is 9, max is 25.", placeholder: "9" },
@@ -155,7 +155,7 @@ function createRevision(value) {
   return createHash("sha1").update(JSON.stringify(sortForHash(value))).digest("hex").slice(0, 12);
 }
 
-function detectRuntimeProfile() {
+export function detectRuntimeProfile() {
   const scriptPath = String(process.argv[1] || "").toLowerCase();
   const execPath = String(process.execPath || "").toLowerCase();
 

--- a/lib/config-ui/app.js
+++ b/lib/config-ui/app.js
@@ -279,7 +279,7 @@ const FIELD_TRANSLATIONS = {
     resetOnNew: { label: "/new 时重置", description: "在使用 counter 模式时需要 hooks.internal.enabled。" },
     queryPrefix: { label: "查询前缀", description: "附加在 query 前面的文本，用于补充检索上下文。" },
     maxQueryChars: { label: "查询最大长度", description: "限制单次查询文本长度，避免 query 过长。" },
-    recallEnabled: { label: "启用召回", description: "控制 before_agent_start 阶段是否执行记忆召回。" },
+    recallEnabled: { label: "启用召回", description: "控制是否在构建提示词前执行记忆召回。" },
     recallGlobal: { label: "全局召回", description: "开启后查询不传 conversation_id，不再强调当前会话权重。" },
     maxItemChars: { label: "注入项最大长度", description: "限制单条召回记忆注入上下文时保留的字符数。" },
     memoryLimitNumber: { label: "记忆数量上限", description: "召回事实记忆的最大条数；默认 9，最大 25。" },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
   "openclaw": {
     "extensions": [
       "./index.js"
-    ]
+    ],
+    "compat": {
+      "pluginApi": ">=2026.5.7"
+    }
   },
   "clawdbot": {
     "extensions": [

--- a/test/recall-hook-registration.test.mjs
+++ b/test/recall-hook-registration.test.mjs
@@ -1,12 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import plugin from "../index.js";
 
-const createApi = (hostVersion) => {
+const createApi = (argv1) => {
   const registeredHooks = [];
   const originalArgv1 = process.argv[1];
-  process.argv[1] = `C:\\Users\\lee\\AppData\\Local\\pnpm\\global\\5\\.pnpm\\openclaw@${hostVersion}\\node_modules\\openclaw\\openclaw.mjs`;
+  process.argv[1] = argv1;
 
   const api = {
     config: { hooks: { internal: { enabled: false } } },
@@ -31,26 +32,55 @@ const createApi = (hostVersion) => {
   };
 };
 
-test("registers before_prompt_build on OpenClaw hosts that support the phase-specific hook", () => {
-  const { api, registeredHooks, restore } = createApi("2026.5.7");
-  try {
-    plugin.register(api);
-  } finally {
-    restore();
-  }
+test("always registers OpenClaw recall on before_prompt_build", async (t) => {
+  const hostEntrypoints = [
+    {
+      name: "versioned host path",
+      value:
+        "C:\\Users\\example\\AppData\\Local\\pnpm\\global\\5\\.pnpm\\openclaw@2026.4.26\\node_modules\\openclaw\\openclaw.mjs",
+    },
+    { name: "unversioned host path", value: "/usr/local/bin/openclaw" },
+  ];
 
-  assert.ok(registeredHooks.some((hook) => hook.hookName === "before_prompt_build"));
-  assert.ok(!registeredHooks.some((hook) => hook.hookName === "before_agent_start"));
+  for (const hostEntrypoint of hostEntrypoints) {
+    await t.test(hostEntrypoint.name, () => {
+      const { api, registeredHooks, restore } = createApi(hostEntrypoint.value);
+      try {
+        plugin.register(api);
+      } finally {
+        restore();
+      }
+
+      assert.ok(registeredHooks.some((hook) => hook.hookName === "before_prompt_build"));
+      assert.ok(!registeredHooks.some((hook) => hook.hookName === "before_agent_start"));
+    });
+  }
 });
 
-test("falls back to before_agent_start on older OpenClaw hosts", () => {
-  const { api, registeredHooks, restore } = createApi("2026.4.26");
-  try {
-    plugin.register(api);
-  } finally {
-    restore();
-  }
+test("preserves recall for declared legacy host entrypoints", async (t) => {
+  const hostEntrypoints = [
+    { name: "Moltbot", value: "/usr/local/lib/node_modules/moltbot/moltbot.mjs" },
+    { name: "ClawDBot", value: "/usr/local/lib/node_modules/clawdbot/clawdbot.mjs" },
+  ];
 
-  assert.ok(registeredHooks.some((hook) => hook.hookName === "before_agent_start"));
-  assert.ok(!registeredHooks.some((hook) => hook.hookName === "before_prompt_build"));
+  for (const hostEntrypoint of hostEntrypoints) {
+    await t.test(hostEntrypoint.name, () => {
+      const { api, registeredHooks, restore } = createApi(hostEntrypoint.value);
+      try {
+        plugin.register(api);
+      } finally {
+        restore();
+      }
+
+      assert.ok(registeredHooks.some((hook) => hook.hookName === "before_agent_start"));
+      assert.ok(!registeredHooks.some((hook) => hook.hookName === "before_prompt_build"));
+    });
+  }
+});
+
+test("declares the minimum supported OpenClaw plugin API", () => {
+  const packageJson = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  );
+  assert.equal(packageJson.openclaw.compat.pluginApi, ">=2026.5.7");
 });


### PR DESCRIPTION
## Summary

- register OpenClaw recall only through `before_prompt_build`
- keep the legacy `before_agent_start` hook only for the separately advertised Moltbot and ClawDBot entrypoints
- declare the minimum supported OpenClaw plugin API and align docs, config UI copy, tests, and release-note generation

## Why

OpenClaw retired `before_agent_start`. The version-path fallback could still register that removed hook on current development builds whose entrypoint did not expose a parseable package version, causing plugin inspection and runtime compatibility failures.

## Verification

- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false npm test`
- `npm pack --dry-run`
- `git diff --check`

Found through the OpenClaw HEAD compatibility canary in `openclaw/crabpot`.
