### PR TITLE
ci: harden npm release propagation verification

### DIFF
--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
@@ -1828,9 +1828,17 @@ export async function reportExternalFailureFromEnv({ fetchImpl = fetch } = {}) {
   const phase = String(process.env.RELEASE_FAILURE_PHASE || "").trim();
   const attemptDir = String(process.env.RELEASE_FAILURE_ATTEMPT_DIR || "").trim();
   if (!phase || !attemptDir) fail("RELEASE_FAILURE_PHASE and RELEASE_FAILURE_ATTEMPT_DIR are required.");
-  const attempts = [1, 2, 3].map((attempt) => {
+  let logNames = [];
+  try {
+    logNames = readdirSync(attemptDir)
+      .filter((name) => /^\d+\.log$/.test(name))
+      .sort((left, right) => Number.parseInt(left, 10) - Number.parseInt(right, 10))
+      .slice(0, 20);
+  } catch {}
+  if (logNames.length === 0) logNames = ["1.log"];
+  const attempts = logNames.map((name) => {
     let message = "attempt log is unavailable";
-    try { message = readFileSync(join(attemptDir, `${attempt}.log`), "utf8"); } catch {}
+    try { message = readFileSync(join(attemptDir, name), "utf8"); } catch {}
     return { error_code: phase.toUpperCase().replace(/[^A-Z0-9]+/g, "_"), message: cleanError(message), retryable: true };
   });
   return reportFailure({
@@ -1840,7 +1848,7 @@ export async function reportExternalFailureFromEnv({ fetchImpl = fetch } = {}) {
       current_tag: process.env.RELEASE_TAG || `${CURRENT_TAG_PREFIX}${cleanVersion(process.env.RELEASE_VERSION)}`,
     },
     attempts,
-    finalError: attempts[2].message,
+    finalError: attempts.at(-1).message,
     phase,
     fetchImpl,
   });

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -1284,6 +1284,40 @@ test("reports three external-operation attempt logs with a sanitized phase", asy
   }
 });
 
+test("reports the real bounded logs in numeric order without inventing missing attempts", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "cloud-plugin-visibility-failure-"));
+  const previous = { ...process.env };
+  try {
+    writeFileSync(join(directory, "1.log"), "first visibility check");
+    writeFileSync(join(directory, "10.log"), "tenth visibility check");
+    writeFileSync(join(directory, "2.log"), "second visibility check");
+    Object.assign(process.env, {
+      RELEASE_FAILURE_PHASE: "npm-publish-verification",
+      RELEASE_FAILURE_ATTEMPT_DIR: directory,
+      RELEASE_VERSION: "0.1.20",
+      RELEASE_TAG: "v0.1.20",
+      DOC_AGENT_RELEASE_FAILURE_URL: "https://example.invalid/failure",
+      DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: "test-token",
+    });
+    let report;
+    await reportExternalFailureFromEnv({
+      fetchImpl: async (_url, options) => {
+        report = JSON.parse(options.body);
+        return response(200, { ok: true });
+      },
+    });
+    assert.deepEqual(report.attempts.map((item) => item.message), [
+      "first visibility check",
+      "second visibility check",
+      "tenth visibility check",
+    ]);
+    assert.equal(report.final_error, "tenth visibility check");
+  } finally {
+    process.env = previous;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("retries transient draft failures and passes prior error context", async () => {
   const previous = { ...process.env };
   try {

--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -150,6 +150,15 @@ test("release workflow publishes committed main versions and pins recovery to np
     /--target "\$\{RELEASE_COMMIT_SHA\}"/,
   );
   assert.match(workflow, /gh api --paginate --slurp/);
+  assert.match(workflow, /wait-for-npm-release\.mjs/);
+  assert.match(workflow, /NPM_VISIBILITY_TIMEOUT_SECONDS: "150"/);
+  assert.match(workflow, /NPM_VISIBILITY_INTERVAL_SECONDS: "10"/);
+  assert.match(
+    workflow,
+    /version, gitHead, and dist-tag were not all visible within \$\{NPM_VISIBILITY_TIMEOUT_SECONDS\}s/,
+  );
+  assert.match(workflow, /GITHUB_RELEASE_VISIBILITY_ATTEMPTS: "12"/);
+  assert.match(workflow, /GITHUB_RELEASE_VISIBILITY_INTERVAL_SECONDS: "10"/);
   assert.match(
     workflow,
     /Refusing to issue a second create request/,
@@ -190,7 +199,17 @@ test("real publishes are branch-gated and reusable callers are immutable dry run
     );
     assert.match(workflow, /dry_run: true/);
     assert.doesNotMatch(workflow, /dry_run: false/);
+    if (name !== "historical-dry-run.yml") {
+      assert.match(workflow, /wait-for-npm-release\.mjs/);
+      assert.match(workflow, /wait-for-npm-release\.test\.mjs/);
+    }
   }
+
+  const contractLintWorkflow = readFileSync(
+    new URL("../workflows/workflow-contract-lint.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(contractLintWorkflow, /wait-for-npm-release\.test\.mjs/);
 });
 
 test("dry-run callers use least privilege and do not inherit all repository secrets", () => {

--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -209,6 +209,12 @@ test("real publishes are branch-gated and reusable callers are immutable dry run
     new URL("../workflows/workflow-contract-lint.yml", import.meta.url),
     "utf8",
   );
+  const preMergeWorkflow = readFileSync(
+    new URL("../workflows/pre-merge-dry-run.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(preMergeWorkflow, /- "fix\/\*\*"/);
+  assert.match(contractLintWorkflow, /- "fix\/\*\*"/);
   assert.match(contractLintWorkflow, /wait-for-npm-release\.test\.mjs/);
 });
 

--- a/.github/scripts/wait-for-npm-release.mjs
+++ b/.github/scripts/wait-for-npm-release.mjs
@@ -1,0 +1,240 @@
+import { pathToFileURL } from "node:url";
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function positiveInteger(value, fallback, name) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+export function npmPackumentUrl(registryUrl, packageName, cacheBust = Date.now()) {
+  const registry = clean(registryUrl || "https://registry.npmjs.org").replace(/\/+$/, "");
+  const name = clean(packageName);
+  if (!name) {
+    throw new Error("NPM_PACKAGE_NAME is required.");
+  }
+  const encodedName = encodeURIComponent(name).replace(/^%40/i, "@");
+  return `${registry}/${encodedName}?cache-bust=${encodeURIComponent(cacheBust)}`;
+}
+
+export function inspectNpmReleaseVisibility({
+  packument,
+  version,
+  distTag,
+  expectedGitHead,
+} = {}) {
+  const targetVersion = clean(version);
+  const targetDistTag = clean(distTag);
+  const expected = clean(expectedGitHead).toLowerCase();
+  if (!targetVersion) {
+    throw new Error("NPM_RELEASE_VERSION is required.");
+  }
+  if (!targetDistTag) {
+    throw new Error("NPM_DIST_TAG is required.");
+  }
+  if (!SHA_PATTERN.test(expected)) {
+    throw new Error("NPM_EXPECTED_GIT_HEAD must be an exact 40-character commit SHA.");
+  }
+
+  const release = packument?.versions?.[targetVersion];
+  if (!release) {
+    return {
+      ok: false,
+      fatal: false,
+      reason: `version ${targetVersion} is not visible`,
+    };
+  }
+
+  const actualGitHead = clean(release.gitHead).toLowerCase();
+  if (!SHA_PATTERN.test(actualGitHead)) {
+    return {
+      ok: false,
+      fatal: false,
+      reason: `version ${targetVersion} is visible but its 40-character gitHead is not`,
+    };
+  }
+  if (actualGitHead !== expected) {
+    return {
+      ok: false,
+      fatal: true,
+      reason: `version ${targetVersion} records gitHead ${actualGitHead}, expected ${expected}`,
+    };
+  }
+
+  const actualDistTagVersion = clean(packument?.["dist-tags"]?.[targetDistTag]);
+  if (actualDistTagVersion !== targetVersion) {
+    return {
+      ok: false,
+      fatal: false,
+      reason:
+        `dist-tag ${targetDistTag} points to ${actualDistTagVersion || "nothing"}, ` +
+        `expected ${targetVersion}`,
+    };
+  }
+
+  return {
+    ok: true,
+    fatal: false,
+    reason: "visible",
+    version: targetVersion,
+    git_head: actualGitHead,
+    dist_tag: targetDistTag,
+    dist_tag_version: actualDistTagVersion,
+  };
+}
+
+function pending(reason) {
+  return { ok: false, fatal: false, reason };
+}
+
+export async function waitForNpmReleaseVisibility(
+  {
+    packageName,
+    version,
+    distTag,
+    expectedGitHead,
+    registryUrl = "https://registry.npmjs.org",
+    timeoutMs = 150_000,
+    intervalMs = 10_000,
+    requestTimeoutMs = 8_000,
+  } = {},
+  {
+    fetchImpl = globalThis.fetch,
+    sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+    now = () => Date.now(),
+    log = (message) => console.log(message),
+  } = {},
+) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("A fetch implementation is required.");
+  }
+  const totalTimeoutMs = positiveInteger(timeoutMs, undefined, "timeoutMs");
+  const pollIntervalMs = positiveInteger(intervalMs, undefined, "intervalMs");
+  const singleRequestTimeoutMs = positiveInteger(
+    requestTimeoutMs,
+    undefined,
+    "requestTimeoutMs",
+  );
+  // Validate immutable inputs before starting the bounded wait.
+  inspectNpmReleaseVisibility({
+    packument: {},
+    version,
+    distTag,
+    expectedGitHead,
+  });
+
+  const startedAt = now();
+  const deadline = startedAt + totalTimeoutMs;
+  let attempt = 0;
+  let lastReport = pending("registry has not been queried");
+
+  while (now() < deadline) {
+    attempt += 1;
+    const remainingBeforeRequest = Math.max(1, deadline - now());
+    const controller = new AbortController();
+    const requestTimer = setTimeout(
+      () => controller.abort(),
+      Math.min(singleRequestTimeoutMs, remainingBeforeRequest),
+    );
+    try {
+      const response = await fetchImpl(npmPackumentUrl(registryUrl, packageName, now()), {
+        headers: {
+          // The install-v1 packument intentionally omits gitHead. The release
+          // gate needs the full metadata document to verify immutable source.
+          accept: "application/json",
+          "cache-control": "no-cache, no-store, max-age=0",
+          pragma: "no-cache",
+        },
+        signal: controller.signal,
+      });
+      if (response.status === 404) {
+        lastReport = pending(`registry returned 404 for ${packageName}`);
+      } else if (response.status === 401 || response.status === 403) {
+        lastReport = {
+          ok: false,
+          fatal: true,
+          reason: `registry returned HTTP ${response.status}`,
+        };
+      } else if (!response.ok) {
+        lastReport = pending(`registry returned HTTP ${response.status}`);
+      } else {
+        lastReport = inspectNpmReleaseVisibility({
+          packument: await response.json(),
+          version,
+          distTag,
+          expectedGitHead,
+        });
+      }
+    } catch (error) {
+      const reason = error?.name === "AbortError" ? "registry request timed out" : clean(error?.message || error);
+      lastReport = pending(reason || "registry request failed");
+    } finally {
+      clearTimeout(requestTimer);
+    }
+
+    if (lastReport.ok) {
+      log(
+        `npm release verified after ${attempt} attempt(s): ` +
+          `${packageName}@${version}, gitHead=${lastReport.git_head}, ` +
+          `${distTag}=${lastReport.dist_tag_version}.`,
+      );
+      return { ...lastReport, attempts: attempt, elapsed_ms: now() - startedAt };
+    }
+    if (lastReport.fatal) {
+      const error = new Error(`npm release verification failed: ${lastReport.reason}.`);
+      error.code = "NPM_METADATA_MISMATCH";
+      throw error;
+    }
+
+    const remaining = deadline - now();
+    log(
+      `npm visibility attempt ${attempt} pending: ${lastReport.reason}; ` +
+        `${Math.max(0, Math.ceil(remaining / 1000))}s remain.`,
+    );
+    if (remaining <= 0) {
+      break;
+    }
+    await sleep(Math.min(pollIntervalMs, remaining));
+  }
+
+  throw new Error(
+    `npm release was not fully visible within ${Math.ceil(totalTimeoutMs / 1000)}s: ` +
+      `${lastReport.reason}.`,
+  );
+}
+
+export async function run(env = process.env) {
+  try {
+    const report = await waitForNpmReleaseVisibility({
+      packageName: env.NPM_PACKAGE_NAME,
+      version: env.NPM_RELEASE_VERSION,
+      distTag: env.NPM_DIST_TAG,
+      expectedGitHead: env.NPM_EXPECTED_GIT_HEAD,
+      registryUrl: env.NPM_CONFIG_REGISTRY || "https://registry.npmjs.org",
+      timeoutMs: positiveInteger(env.NPM_VISIBILITY_TIMEOUT_SECONDS, 150, "timeout") * 1000,
+      intervalMs: positiveInteger(env.NPM_VISIBILITY_INTERVAL_SECONDS, 10, "interval") * 1000,
+      requestTimeoutMs:
+        positiveInteger(env.NPM_VISIBILITY_REQUEST_TIMEOUT_SECONDS, 8, "request timeout") * 1000,
+    });
+    console.log(JSON.stringify(report));
+    return report;
+  } catch (error) {
+    console.error(`::error::${clean(error?.message || error)}`);
+    process.exitCode = error?.code === "NPM_METADATA_MISMATCH" ? 2 : 1;
+    return null;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await run();
+}

--- a/.github/scripts/wait-for-npm-release.test.mjs
+++ b/.github/scripts/wait-for-npm-release.test.mjs
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  inspectNpmReleaseVisibility,
+  npmPackumentUrl,
+  waitForNpmReleaseVisibility,
+} from "./wait-for-npm-release.mjs";
+
+const sha = "a317661691bda94054d3d35f8c226e8bfe0018f7";
+
+function response(packument, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return packument;
+    },
+  };
+}
+
+function packument({ version = "0.1.20", gitHead = sha, latest = "0.1.20" } = {}) {
+  return {
+    "dist-tags": { latest },
+    versions: { [version]: { gitHead } },
+  };
+}
+
+test("builds a cache-busted scoped-package registry URL", () => {
+  assert.equal(
+    npmPackumentUrl("https://registry.npmjs.org/", "@memtensor/plugin", 123),
+    "https://registry.npmjs.org/@memtensor%2Fplugin?cache-bust=123",
+  );
+});
+
+test("requests the full packument because install-v1 omits gitHead", async () => {
+  let requestHeaders;
+  const report = await waitForNpmReleaseVisibility(
+    {
+      packageName: "@memtensor/plugin",
+      version: "0.1.20",
+      distTag: "latest",
+      expectedGitHead: sha,
+      timeoutMs: 10_000,
+      intervalMs: 1_000,
+      requestTimeoutMs: 1_000,
+    },
+    {
+      fetchImpl: async (_url, options) => {
+        requestHeaders = options.headers;
+        return response(packument());
+      },
+      log: () => {},
+    },
+  );
+  assert.equal(report.ok, true);
+  assert.equal(requestHeaders.accept, "application/json");
+});
+
+test("requires version, gitHead, and dist-tag to become visible together", () => {
+  assert.match(
+    inspectNpmReleaseVisibility({
+      packument: { versions: {}, "dist-tags": {} },
+      version: "0.1.20",
+      distTag: "latest",
+      expectedGitHead: sha,
+    }).reason,
+    /not visible/,
+  );
+  assert.match(
+    inspectNpmReleaseVisibility({
+      packument: packument({ gitHead: "" }),
+      version: "0.1.20",
+      distTag: "latest",
+      expectedGitHead: sha,
+    }).reason,
+    /gitHead is not/,
+  );
+  assert.match(
+    inspectNpmReleaseVisibility({
+      packument: packument({ latest: "0.1.19" }),
+      version: "0.1.20",
+      distTag: "latest",
+      expectedGitHead: sha,
+    }).reason,
+    /latest points to 0\.1\.19/,
+  );
+  assert.equal(
+    inspectNpmReleaseVisibility({
+      packument: packument(),
+      version: "0.1.20",
+      distTag: "latest",
+      expectedGitHead: sha,
+    }).ok,
+    true,
+  );
+});
+
+test("fails immediately when npm exposes a different immutable gitHead", async () => {
+  let sleeps = 0;
+  await assert.rejects(
+    waitForNpmReleaseVisibility(
+      {
+        packageName: "@memtensor/plugin",
+        version: "0.1.20",
+        distTag: "latest",
+        expectedGitHead: sha,
+        timeoutMs: 150_000,
+        intervalMs: 10_000,
+        requestTimeoutMs: 1_000,
+      },
+      {
+        fetchImpl: async () => response(packument({ gitHead: "b".repeat(40) })),
+        sleep: async () => {
+          sleeps += 1;
+        },
+        log: () => {},
+      },
+    ),
+    /records gitHead .* expected/,
+  );
+  assert.equal(sleeps, 0);
+});
+
+test("waits through delayed version, gitHead, and dist-tag propagation", async () => {
+  let clock = 0;
+  let attempt = 0;
+  const replies = [
+    response({}, 404),
+    response(packument({ gitHead: "" })),
+    response(packument({ latest: "0.1.19" })),
+    response(packument()),
+  ];
+  const report = await waitForNpmReleaseVisibility(
+    {
+      packageName: "@memtensor/plugin",
+      version: "0.1.20",
+      distTag: "latest",
+      expectedGitHead: sha,
+      timeoutMs: 150_000,
+      intervalMs: 10_000,
+      requestTimeoutMs: 1_000,
+    },
+    {
+      fetchImpl: async () => replies[attempt++],
+      sleep: async (milliseconds) => {
+        clock += milliseconds;
+      },
+      now: () => clock,
+      log: () => {},
+    },
+  );
+  assert.equal(report.ok, true);
+  assert.equal(report.attempts, 4);
+  assert.equal(clock, 30_000);
+});
+
+test("uses a hard deadline instead of an unbounded retry loop", async () => {
+  let clock = 0;
+  let attempts = 0;
+  await assert.rejects(
+    waitForNpmReleaseVisibility(
+      {
+        packageName: "@memtensor/plugin",
+        version: "0.1.20",
+        distTag: "latest",
+        expectedGitHead: sha,
+        timeoutMs: 30_000,
+        intervalMs: 10_000,
+        requestTimeoutMs: 1_000,
+      },
+      {
+        fetchImpl: async () => {
+          attempts += 1;
+          return response({}, 404);
+        },
+        sleep: async (milliseconds) => {
+          clock += milliseconds;
+        },
+        now: () => clock,
+        log: () => {},
+      },
+    ),
+    /not fully visible within 30s/,
+  );
+  assert.equal(clock, 30_000);
+  assert.equal(attempts, 3);
+});

--- a/.github/workflows/post-merge-dry-run.yml
+++ b/.github/workflows/post-merge-dry-run.yml
@@ -19,6 +19,8 @@ on:
       - ".github/scripts/validate-release-confirmation.test.mjs"
       - ".github/scripts/validate-release-source-version.mjs"
       - ".github/scripts/validate-release-source-version.test.mjs"
+      - ".github/scripts/wait-for-npm-release.mjs"
+      - ".github/scripts/wait-for-npm-release.test.mjs"
       - ".github/scripts/retry.sh"
       - "package.json"
       - "scripts/generate-telemetry-credentials.cjs"

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -19,6 +19,8 @@ on:
       - ".github/scripts/validate-release-confirmation.test.mjs"
       - ".github/scripts/validate-release-source-version.mjs"
       - ".github/scripts/validate-release-source-version.test.mjs"
+      - ".github/scripts/wait-for-npm-release.mjs"
+      - ".github/scripts/wait-for-npm-release.test.mjs"
       - ".github/scripts/retry.sh"
       - "package.json"
       - "scripts/generate-telemetry-credentials.cjs"

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "docs-sync/**"
+      - "fix/**"
     paths:
       - ".github/workflows/release.yml"
       - ".github/workflows/release-dry-run.yml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,8 +201,12 @@ jobs:
                   return 0
                 fi
                 sed -n '1,80p' "${out}" >&2
-                echo "::error::${PACKAGE_NAME}@${RELEASE_VERSION} has no trustworthy 40-character npm gitHead." >&2
-                return 1
+                if [ "${attempt}" = 3 ]; then
+                  echo "::error::${PACKAGE_NAME}@${RELEASE_VERSION} has no trustworthy 40-character npm gitHead after three attempts." >&2
+                  return 1
+                fi
+                sleep "$((attempt * 5))"
+                continue
               fi
               sed -n '1,80p' "${out}" >&2
               if [ "${attempt}" = 3 ]; then
@@ -519,6 +523,9 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
+          NPM_VISIBILITY_TIMEOUT_SECONDS: "150"
+          NPM_VISIBILITY_INTERVAL_SECONDS: "10"
+          NPM_VISIBILITY_REQUEST_TIMEOUT_SECONDS: "8"
         run: |
           set -euo pipefail
 
@@ -570,8 +577,12 @@ jobs:
                   return 0
                 fi
                 sed -n '1,80p' "${out}" >&2
-                echo "::error::${PACKAGE_NAME}@${RELEASE_VERSION} has no trustworthy 40-character npm gitHead." >&2
-                return 1
+                if [ "${attempt}" = 3 ]; then
+                  echo "::error::${PACKAGE_NAME}@${RELEASE_VERSION} has no trustworthy 40-character npm gitHead after three attempts." >&2
+                  return 1
+                fi
+                sleep "$((attempt * 5))"
+                continue
               fi
               sed -n '1,80p' "${out}" >&2
               if [ "${attempt}" = 3 ]; then
@@ -580,6 +591,17 @@ jobs:
               fi
               sleep "$((attempt * 5))"
             done
+          }
+          wait_for_npm_release_visibility() {
+            local expected_git_head="$1"
+            NPM_PACKAGE_NAME="${PACKAGE_NAME}" \
+              NPM_RELEASE_VERSION="${RELEASE_VERSION}" \
+              NPM_DIST_TAG="${NPM_DIST_TAG}" \
+              NPM_EXPECTED_GIT_HEAD="${expected_git_head}" \
+              NPM_VISIBILITY_TIMEOUT_SECONDS="${NPM_VISIBILITY_TIMEOUT_SECONDS}" \
+              NPM_VISIBILITY_INTERVAL_SECONDS="${NPM_VISIBILITY_INTERVAL_SECONDS}" \
+              NPM_VISIBILITY_REQUEST_TIMEOUT_SECONDS="${NPM_VISIBILITY_REQUEST_TIMEOUT_SECONDS}" \
+              node .github/scripts/wait-for-npm-release.mjs
           }
           ensure_commit_available() {
             local commit_sha="$1"
@@ -764,45 +786,40 @@ jobs:
               publish_status=$?
               set -e
               sed -n '1,160p' "${attempt_dir}/${attempt}.log"
-              if [ "${publish_status}" = 0 ]; then
-                for poll_attempt in 1 2 3; do
-                  if npm_version_exists; then
-                    publish_confirmed=true
-                    break
-                  fi
-                  sleep "$((poll_attempt * 2))"
-                done
-                if [ "${publish_confirmed}" != "true" ]; then
-                  echo "::error::npm publish returned success, but the version could not be verified. Refusing to issue a second publish request."
-                  exit 1
+              set +e
+              wait_for_npm_release_visibility "${release_commit_sha}" 2>&1 |
+                tee -a "${attempt_dir}/${attempt}.log"
+              visibility_status="${PIPESTATUS[0]}"
+              set -e
+              if [ "${visibility_status}" = 0 ]; then
+                publish_confirmed=true
+              elif [ "${visibility_status}" = 2 ]; then
+                report_exhausted_failure "npm-publish-verification" "${attempt_dir}"
+                echo "::error::npm exposed immutable metadata that does not match the reviewed release source; refusing any publish retry."
+                exit 1
+              fi
+              if [ "${publish_confirmed}" = "true" ]; then
+                if [ "${publish_status}" = 0 ]; then
+                  echo "npm publish and the bounded registry visibility check both succeeded."
+                else
+                  echo "Publish returned an error, but npm now contains the fully verified release; refusing a duplicate publish."
                 fi
                 break
               fi
-              for poll_attempt in 1 2 3; do
-                if npm_version_exists; then
-                  publish_confirmed=true
-                  break
-                fi
-                sleep "$((poll_attempt * 2))"
-              done
-              if [ "${publish_confirmed}" = "true" ]; then
-                echo "Publish returned an error, but npm now contains the requested version; refusing a duplicate publish."
-                break
+              if [ "${publish_status}" = 0 ]; then
+                report_exhausted_failure "npm-publish-verification" "${attempt_dir}"
+                echo "::error::npm publish returned success, but version, gitHead, and dist-tag were not all visible within ${NPM_VISIBILITY_TIMEOUT_SECONDS}s. Refusing to issue a second publish request."
+                exit 1
               fi
               if [ "${attempt}" = 3 ]; then
                 report_exhausted_failure "npm-publish" "${attempt_dir}"
-                echo "::error::npm publish failed after three attempts."
+                echo "::error::npm publish failed after three attempts, and no fully verified release became visible."
                 exit 1
               fi
               sleep "$((attempt * 5))"
             done
             if [ "${publish_confirmed}" != "true" ]; then
               echo "::error::npm publish appeared to finish, but ${PACKAGE_NAME}@${RELEASE_VERSION} is still not visible."
-              exit 1
-            fi
-            npm_git_head="$(npm_release_git_head)"
-            if [ "${npm_git_head}" != "${release_commit_sha}" ]; then
-              echo "::error::Published npm gitHead ${npm_git_head} does not match release commit ${release_commit_sha}."
               exit 1
             fi
           fi
@@ -820,6 +837,8 @@ jobs:
           RELEASE_COMMIT_SHA: ${{ steps.publish_npm.outputs.release_commit_sha }}
           DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
+          GITHUB_RELEASE_VISIBILITY_ATTEMPTS: "12"
+          GITHUB_RELEASE_VISIBILITY_INTERVAL_SECONDS: "10"
         run: |
           set -euo pipefail
           if [ -z "${RELEASE_NOTES_FILE}" ] || [ ! -s "${RELEASE_NOTES_FILE}" ]; then
@@ -950,7 +969,7 @@ jobs:
               echo "::endgroup::"
 
               release_verified=false
-              for poll_attempt in 1 2 3; do
+              for poll_attempt in $(seq 1 "${GITHUB_RELEASE_VISIBILITY_ATTEMPTS}"); do
                 refresh_release_inventory
                 set +e
                 release_inventory_report="$(inspect_release_inventory true)"
@@ -972,8 +991,8 @@ jobs:
                   echo "::error::${release_inventory_report}"
                   exit 1
                 fi
-                if [ "${poll_attempt}" -lt 3 ]; then
-                  sleep "$((poll_attempt * 2))"
+                if [ "${poll_attempt}" -lt "${GITHUB_RELEASE_VISIBILITY_ATTEMPTS}" ]; then
+                  sleep "${GITHUB_RELEASE_VISIBILITY_INTERVAL_SECONDS}"
                 fi
               done
 

--- a/.github/workflows/workflow-contract-lint.yml
+++ b/.github/workflows/workflow-contract-lint.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "docs-sync/**"
+      - "fix/**"
     paths:
       - ".github/workflows/**"
       - ".github/scripts/validate-github-release-inventory.mjs"

--- a/.github/workflows/workflow-contract-lint.yml
+++ b/.github/workflows/workflow-contract-lint.yml
@@ -13,6 +13,8 @@ on:
       - ".github/scripts/validate-release-confirmation.test.mjs"
       - ".github/scripts/validate-release-source-version.mjs"
       - ".github/scripts/validate-release-source-version.test.mjs"
+      - ".github/scripts/wait-for-npm-release.mjs"
+      - ".github/scripts/wait-for-npm-release.test.mjs"
 
 permissions:
   contents: read
@@ -58,4 +60,4 @@ jobs:
 
       - name: Validate reusable workflow boundaries
         shell: bash
-        run: node --test .github/scripts/validate-github-release-inventory.test.mjs .github/scripts/validate-release-confirmation.test.mjs .github/scripts/validate-release-source-version.test.mjs
+        run: node --test .github/scripts/validate-github-release-inventory.test.mjs .github/scripts/validate-release-confirmation.test.mjs .github/scripts/validate-release-source-version.test.mjs .github/scripts/wait-for-npm-release.test.mjs


### PR DESCRIPTION
## Summary

- replace the roughly 12-second post-publish check with a hard 150-second npm visibility deadline, polling every 10 seconds
- verify the published version, exact 40-character `gitHead`, and requested dist-tag together from a cache-busted full npm packument
- fail closed on immutable source mismatch, and never issue a second publish request after `npm publish` returned success
- tolerate temporarily empty npm `gitHead` values and extend bounded GitHub Release visibility verification
- preserve the real bounded attempt logs in the sanitized Doc Agent failure report
- make the new helper and tests trigger pre-merge, post-merge, and workflow-contract checks

## Why

The 0.1.20 release run published npm successfully, but the old verifier only waited about 12 seconds. npm metadata was not visible within that window, so the workflow stopped before creating the tag and Published GitHub Release. The package later became fully visible with the expected source commit.

This change treats registry propagation as a bounded eventual-consistency wait while retaining fail-closed and idempotency protections.

## Validation

- `npm test`: 127/127 passed
- npm visibility unit tests cover delayed version, delayed `gitHead`, delayed dist-tag, immutable mismatch, full-packument media type, and hard timeout
- all changed Workflow YAML files parse successfully
- `npm pack --dry-run --json` passed with the expected 17 package files
- read-only live npm check verified `0.1.20`, `gitHead=a317661691bda94054d3d35f8c226e8bfe0018f7`, and `latest=0.1.20`
- `git diff --check` and sensitive-value scan passed

## Safety

This branch did not publish npm, create or change tags/Releases, trigger Docs sync, or modify production state. The existing partially completed 0.1.20 release remains a separate explicit recovery action after review.
