### PR TITLE
ci: automate cloud plugin draft releases

### DIFF
--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -1,0 +1,29 @@
+# Reviewed OpenClaw cloud plugin Release Notes
+
+This directory is optional. A version-bump pull request may add
+`.github/release-notes/v<version>.md` when release owners want to provide the
+reviewed GitHub Release body themselves. For example:
+
+```text
+.github/release-notes/v0.1.21.md
+```
+
+The version in the filename must match all four committed version files. No
+special branch name is required. The file must use the same evidence-backed
+contract as the former `release_notes` workflow input:
+
+- public `## Changelog` Markdown;
+- one hidden `doc-agent-release-notes-json` block containing bilingual items
+  and real `source_refs`;
+- one exact `<!-- doc-agent: source-id=openclaw-cloud-plugin -->` marker.
+
+The release workflow validates the file. Invalid manual notes fail closed and
+cannot publish npm, a tag, or a Draft Release.
+
+The automatic workflow reads this file directly from the immutable merged
+commit. It does not copy the Markdown through cross-job outputs and does not
+create a version-update pull request.
+
+When this file is absent, the workflow collects immutable git evidence and asks
+the configured 106 Doc Agent draft endpoint to generate and repair the same
+contract. Do not commit internal URLs, tokens, prompts, or unredacted logs here.

--- a/.github/scripts/draft-cloud-plugin-release-notes.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.mjs
@@ -1972,7 +1972,30 @@ export async function main() {
   const docsPreviewMarkdownPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-docs-preview.md`);
   const qualityReportPath = join(tmpdir(), `openclaw-cloud-plugin-${targetVersion}-quality-report.json`);
 
-  const suppliedManualNotes = String(process.env.MANUAL_RELEASE_NOTES || "").trim();
+  const suppliedManualNotesFile = String(
+    process.env.MANUAL_RELEASE_NOTES_FILE || "",
+  ).trim();
+  const suppliedManualNotesInput = String(
+    process.env.MANUAL_RELEASE_NOTES || "",
+  ).trim();
+  if (suppliedManualNotesFile && suppliedManualNotesInput) {
+    fail(
+      "Provide reviewed Release Notes through either MANUAL_RELEASE_NOTES_FILE or MANUAL_RELEASE_NOTES, not both.",
+    );
+  }
+  let suppliedManualNotes = suppliedManualNotesInput;
+  if (suppliedManualNotesFile) {
+    try {
+      suppliedManualNotes = readFileSync(suppliedManualNotesFile, "utf8").trim();
+    } catch (error) {
+      fail(
+        `Cannot read reviewed Release Notes file ${suppliedManualNotesFile}: ${cleanError(error?.message || error)}`,
+      );
+    }
+    if (!suppliedManualNotes) {
+      fail(`Reviewed Release Notes file ${suppliedManualNotesFile} is empty.`);
+    }
+  }
   const manualNotes =
     faultCase === "manual_notes_missing_payload"
       ? "## Changelog\n\n### Added\n- Intentionally missing the hidden evidence payload."

--- a/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-cloud-plugin-release-notes.test.mjs
@@ -1180,20 +1180,22 @@ test("manual release notes also produce docs preview outputs", async () => {
   try {
     const outputPath = join(directory, "github-output.txt");
     const notesPath = join(directory, "release-notes.md");
+    const reviewedNotesPath = join(directory, "v0.1.19.md");
     const sourceRef = runGit(process.cwd(), ["rev-parse", "--short", "d053b0a"]);
-    Object.assign(process.env, {
-      RELEASE_VERSION: "0.1.19",
-      RELEASE_TAG: "v0.1.19",
-      RELEASE_EVIDENCE_REF: "v0.1.19",
-      RELEASE_NOTES_FILE: notesPath,
-      MANUAL_RELEASE_NOTES: `## Changelog
+    writeFileSync(reviewedNotesPath, `## Changelog
 
 ### Improved
 - **系统提示识别优化**：兼容单行压缩内容并降低普通消息误判概率。
 
 <!-- doc-agent-release-notes-json
 {"items":[{"category":"Improved","text_cn":"**系统提示识别优化**：兼容单行压缩内容并降低普通消息误判概率。","text_en":"**System prompt detection**: Supports flattened single-line prompts and reduces false positives on regular messages.","source_refs":["${sourceRef}"]}],"coverage":{"needs_review":false,"required_count":1,"covered_required_count":1,"missing_required_count":0}}
--->`,
+-->`, "utf8");
+    Object.assign(process.env, {
+      RELEASE_VERSION: "0.1.19",
+      RELEASE_TAG: "v0.1.19",
+      RELEASE_EVIDENCE_REF: "v0.1.19",
+      RELEASE_NOTES_FILE: notesPath,
+      MANUAL_RELEASE_NOTES_FILE: reviewedNotesPath,
       GITHUB_OUTPUT: outputPath,
     });
 

--- a/.github/scripts/resolve-auto-release.mjs
+++ b/.github/scripts/resolve-auto-release.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { compareSemver, parseSemver } from "../../lib/semver.js";
+
+export const VERSION_FILES = [
+  "package.json",
+  "openclaw.plugin.json",
+  "moltbot.plugin.json",
+  "clawdbot.plugin.json",
+];
+
+function clean(value) {
+  return String(value ?? "").trim();
+}
+
+function exactSha(value) {
+  return /^[0-9a-fA-F]{40}$/.test(clean(value));
+}
+
+export function npmDistTagForVersion(version) {
+  const parsed = parseSemver(version);
+  if (!parsed) throw new Error(`version must be valid SemVer; got '${clean(version)}'`);
+  if (parsed.prerelease.length === 0) return "latest";
+  const identifier = String(parsed.prerelease[0] || "").toLowerCase();
+  return ["alpha", "beta", "next"].includes(identifier) ? identifier : "next";
+}
+
+export function versionsFromFiles(root = process.cwd()) {
+  return Object.fromEntries(
+    VERSION_FILES.map((file) => {
+      const payload = JSON.parse(readFileSync(join(root, file), "utf8"));
+      return [file, clean(payload.version)];
+    }),
+  );
+}
+
+export function versionsFromGitRef(ref, root = process.cwd()) {
+  const sourceRef = clean(ref);
+  if (!sourceRef) throw new Error("a git ref is required to read previous versions");
+  return Object.fromEntries(
+    VERSION_FILES.map((file) => {
+      const raw = execFileSync("git", ["show", `${sourceRef}:${file}`], {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      return [file, clean(JSON.parse(raw).version)];
+    }),
+  );
+}
+
+function changedVersionFiles(previousVersions, currentVersions) {
+  return VERSION_FILES.filter(
+    (file) => clean(previousVersions?.[file]) !== clean(currentVersions?.[file]),
+  );
+}
+
+function commonVersion(versions, label) {
+  const values = VERSION_FILES.map((file) => clean(versions?.[file]));
+  const missing = VERSION_FILES.filter((_, index) => !values[index]);
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      reason: `${label} is missing version values in ${missing.join(", ")}`,
+    };
+  }
+  const unique = [...new Set(values)];
+  if (unique.length !== 1) {
+    return {
+      ok: false,
+      reason: `${label} has inconsistent versions: ${VERSION_FILES.map((file) => `${file}=${clean(versions?.[file]) || "missing"}`).join(", ")}`,
+    };
+  }
+  return { ok: true, version: unique[0] };
+}
+
+export function inspectVersionTransition({ previousVersions, currentVersions }) {
+  const changedFiles = changedVersionFiles(previousVersions, currentVersions);
+  if (changedFiles.length === 0) {
+    return {
+      ok: true,
+      eligible: false,
+      reason: "the merge did not change any release version value",
+      changed_version_files: [],
+    };
+  }
+
+  const previous = commonVersion(previousVersions, "the pre-merge main source");
+  if (!previous.ok) return { ...previous, eligible: false, changed_version_files: changedFiles };
+  if (changedFiles.length !== VERSION_FILES.length) {
+    const unchanged = VERSION_FILES.filter((file) => !changedFiles.includes(file));
+    return {
+      ok: false,
+      eligible: false,
+      reason: `a release version changed, but all four version files were not updated; unchanged: ${unchanged.join(", ")}`,
+      previous_version: previous.version,
+      version: "",
+      changed_version_files: changedFiles,
+    };
+  }
+  const current = commonVersion(currentVersions, "the merged main source");
+  if (!current.ok) return { ...current, eligible: false, changed_version_files: changedFiles };
+  if (!parseSemver(previous.version) || !parseSemver(current.version)) {
+    return {
+      ok: false,
+      eligible: false,
+      reason: `release versions must be strict SemVer; got ${previous.version} -> ${current.version}`,
+      previous_version: previous.version,
+      version: current.version,
+      changed_version_files: changedFiles,
+    };
+  }
+  if (previous.version.includes("+") || current.version.includes("+")) {
+    return {
+      ok: false,
+      eligible: false,
+      reason: "automatic releases reject SemVer build metadata because npm precedence and immutable v-tags would become ambiguous",
+      previous_version: previous.version,
+      version: current.version,
+      changed_version_files: changedFiles,
+    };
+  }
+  if (compareSemver(current.version, previous.version) <= 0) {
+    return {
+      ok: false,
+      eligible: false,
+      reason: `release version must increase by SemVer precedence; got ${previous.version} -> ${current.version}`,
+      previous_version: previous.version,
+      version: current.version,
+      changed_version_files: changedFiles,
+    };
+  }
+
+  return {
+    ok: true,
+    eligible: true,
+    reason: `all four committed versions increased from ${previous.version} to ${current.version}`,
+    previous_version: previous.version,
+    version: current.version,
+    npm_dist_tag: npmDistTagForVersion(current.version),
+    github_release_prerelease: parseSemver(current.version).prerelease.length > 0,
+    release_notes_path: `.github/release-notes/v${current.version}.md`,
+    changed_version_files: changedFiles,
+  };
+}
+
+export function inspectPullRequestEvent({
+  eventName,
+  merged,
+  baseRef,
+  headRepo,
+  repository,
+  mergeSha,
+  baseSha,
+}) {
+  if (eventName !== "pull_request") {
+    return { ok: true, inspect: false, reason: "manual workflow dispatch" };
+  }
+  if (clean(merged).toLowerCase() !== "true") {
+    return { ok: true, inspect: false, reason: "pull request closed without merge" };
+  }
+  if (baseRef !== "main") {
+    return { ok: true, inspect: false, reason: `pull request targets ${baseRef || "an unknown branch"}, not main` };
+  }
+  if (headRepo !== repository) {
+    return { ok: true, inspect: false, reason: "fork pull requests cannot authorize an automatic release" };
+  }
+  if (!exactSha(mergeSha) || !exactSha(baseSha)) {
+    return {
+      ok: false,
+      inspect: false,
+      reason: "merged PR must provide exact 40-character base and merge commit SHAs",
+    };
+  }
+  return { ok: true, inspect: true, reason: "same-repository PR merged into main" };
+}
+
+export function validateAutoRelease({
+  eventName,
+  merged,
+  baseRef,
+  headRepo,
+  repository,
+  mergeSha,
+  baseSha,
+  previousVersions,
+  currentVersions,
+}) {
+  const event = inspectPullRequestEvent({
+    eventName,
+    merged,
+    baseRef,
+    headRepo,
+    repository,
+    mergeSha,
+    baseSha,
+  });
+  if (!event.ok || !event.inspect) return { ...event, eligible: false };
+  const transition = inspectVersionTransition({ previousVersions, currentVersions });
+  return {
+    ...transition,
+    inspect: true,
+    target_sha: clean(mergeSha),
+    base_sha: clean(baseSha),
+  };
+}
+
+function writeOutputs(result, outputFile) {
+  if (!outputFile) return;
+  appendFileSync(
+    outputFile,
+    [
+      `eligible=${result.eligible === true}`,
+      `reason=${clean(result.reason).replaceAll("\n", " ")}`,
+      `previous_version=${result.previous_version || ""}`,
+      `version=${result.version || ""}`,
+      `npm_dist_tag=${result.npm_dist_tag || ""}`,
+      `github_release_prerelease=${result.github_release_prerelease === true}`,
+      `target_sha=${result.target_sha || ""}`,
+      `base_sha=${result.base_sha || ""}`,
+      `release_notes_path=${result.release_notes_path || ""}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+export function main(env = process.env) {
+  const event = inspectPullRequestEvent({
+    eventName: env.EVENT_NAME,
+    merged: env.PR_MERGED,
+    baseRef: env.PR_BASE_REF,
+    headRepo: env.PR_HEAD_REPO,
+    repository: env.GITHUB_REPOSITORY,
+    mergeSha: env.PR_MERGE_SHA,
+    baseSha: env.PR_BASE_SHA,
+  });
+  if (!event.ok || !event.inspect) {
+    const result = { ...event, eligible: false };
+    writeOutputs(result, env.GITHUB_OUTPUT);
+    if (!result.ok) throw new Error(result.reason);
+    console.log(`Automatic release skipped: ${result.reason}`);
+    return result;
+  }
+  const root = env.GITHUB_WORKSPACE || process.cwd();
+  const currentVersions = versionsFromGitRef(env.PR_MERGE_SHA, root);
+  const previousVersions = versionsFromGitRef(env.PR_BASE_SHA, root);
+  const result = validateAutoRelease({
+    eventName: env.EVENT_NAME,
+    merged: env.PR_MERGED,
+    baseRef: env.PR_BASE_REF,
+    headRepo: env.PR_HEAD_REPO,
+    repository: env.GITHUB_REPOSITORY,
+    mergeSha: env.PR_MERGE_SHA,
+    baseSha: env.PR_BASE_SHA,
+    previousVersions,
+    currentVersions,
+  });
+  writeOutputs(result, env.GITHUB_OUTPUT);
+  if (!result.ok) throw new Error(result.reason);
+  console.log(
+    result.eligible
+      ? `Automatic release accepted: ${result.previous_version} -> ${result.version}, npm tag=${result.npm_dist_tag}, target=${result.target_sha}`
+      : `Automatic release skipped: ${result.reason}`,
+  );
+  return result;
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::${error?.message || String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/resolve-auto-release.test.mjs
+++ b/.github/scripts/resolve-auto-release.test.mjs
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  VERSION_FILES,
+  inspectPullRequestEvent,
+  inspectVersionTransition,
+  npmDistTagForVersion,
+  validateAutoRelease,
+  versionsFromGitRef,
+} from "./resolve-auto-release.mjs";
+
+const MERGE_SHA = "a".repeat(40);
+const BASE_SHA = "b".repeat(40);
+const REPO = "MemTensor/MemOS-Cloud-OpenClaw-Plugin";
+
+function versions(version) {
+  return Object.fromEntries(VERSION_FILES.map((file) => [file, version]));
+}
+
+function valid(overrides = {}) {
+  return {
+    eventName: "pull_request",
+    merged: "true",
+    baseRef: "main",
+    headRepo: REPO,
+    repository: REPO,
+    mergeSha: MERGE_SHA,
+    baseSha: BASE_SHA,
+    previousVersions: versions("0.1.20"),
+    currentVersions: versions("0.1.21"),
+    ...overrides,
+  };
+}
+
+test("accepts a four-file stable version increase without relying on the branch name", () => {
+  const result = validateAutoRelease(valid());
+  assert.equal(result.ok, true);
+  assert.equal(result.eligible, true);
+  assert.equal(result.previous_version, "0.1.20");
+  assert.equal(result.version, "0.1.21");
+  assert.equal(result.npm_dist_tag, "latest");
+  assert.equal(result.github_release_prerelease, false);
+  assert.equal(result.target_sha, MERGE_SHA);
+  assert.equal(result.release_notes_path, ".github/release-notes/v0.1.21.md");
+});
+
+test("derives beta, alpha, next, and fallback prerelease npm channels", () => {
+  assert.equal(npmDistTagForVersion("0.1.21-beta.1"), "beta");
+  assert.equal(npmDistTagForVersion("0.1.21-alpha.2"), "alpha");
+  assert.equal(npmDistTagForVersion("0.1.21-next.3"), "next");
+  assert.equal(npmDistTagForVersion("0.1.21-rc.1"), "next");
+
+  const beta = validateAutoRelease(
+    valid({ currentVersions: versions("0.1.21-beta.0") }),
+  );
+  assert.equal(beta.ok, true);
+  assert.equal(beta.eligible, true);
+  assert.equal(beta.npm_dist_tag, "beta");
+  assert.equal(beta.github_release_prerelease, true);
+});
+
+test("skips ordinary merges whose four version values are unchanged", () => {
+  const result = validateAutoRelease(
+    valid({ currentVersions: versions("0.1.20") }),
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.eligible, false);
+  assert.match(result.reason, /did not change/);
+});
+
+test("fails closed when only some version files change", () => {
+  const current = versions("0.1.20");
+  current["package.json"] = "0.1.21";
+  const result = inspectVersionTransition({
+    previousVersions: versions("0.1.20"),
+    currentVersions: current,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /all four version files were not updated/);
+});
+
+test("fails closed when the merged versions disagree", () => {
+  const current = versions("0.1.21");
+  current["moltbot.plugin.json"] = "0.1.22";
+  const result = validateAutoRelease(valid({ currentVersions: current }));
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /inconsistent versions/);
+});
+
+test("rejects downgrades, equal precedence, and build metadata", () => {
+  for (const [previous, current, pattern] of [
+    ["0.1.21", "0.1.20", /must increase/],
+    ["0.1.21", "0.1.21-beta.1", /must increase/],
+    ["0.1.21+build.1", "0.1.21+build.2", /build metadata/],
+  ]) {
+    const result = inspectVersionTransition({
+      previousVersions: versions(previous),
+      currentVersions: versions(current),
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.reason, pattern);
+  }
+});
+
+test("accepts beta increments and beta-to-stable promotion", () => {
+  for (const [previous, current] of [
+    ["0.1.21-beta.0", "0.1.21-beta.1"],
+    ["0.1.21-beta.1", "0.1.21"],
+  ]) {
+    const result = inspectVersionTransition({
+      previousVersions: versions(previous),
+      currentVersions: versions(current),
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.eligible, true);
+  }
+});
+
+test("ignores unmerged, fork, and non-main pull requests", () => {
+  for (const input of [
+    valid({ merged: "false" }),
+    valid({ headRepo: "someone/fork" }),
+    valid({ baseRef: "test" }),
+  ]) {
+    const result = inspectPullRequestEvent(input);
+    assert.equal(result.ok, true);
+    assert.equal(result.inspect, false);
+  }
+});
+
+test("requires immutable base and merge SHAs for eligible merged PRs", () => {
+  for (const input of [
+    valid({ mergeSha: "abc123" }),
+    valid({ baseSha: "abc123" }),
+  ]) {
+    const result = validateAutoRelease(input);
+    assert.equal(result.ok, false);
+    assert.match(result.reason, /40-character/);
+  }
+});
+
+test("replays historical beta, stable, and ordinary main merges from immutable refs", () => {
+  for (const [mergeSha, expected] of [
+    ["066f330d00c710ee3e618312c145f58c51c0d84c", { eligible: true, version: "0.1.20-beta.0", tag: "beta" }],
+    ["a317661691bda94054d3d35f8c226e8bfe0018f7", { eligible: true, version: "0.1.20", tag: "latest" }],
+    ["bf3f9b32003c58368521b3f11cdb2bef707f3b13", { eligible: false }],
+  ]) {
+    let baseSha;
+    try {
+      baseSha = String(
+        execFileSync("git", ["rev-parse", `${mergeSha}^1`], {
+          encoding: "utf8",
+        }),
+      ).trim();
+    } catch {
+      return;
+    }
+    const result = validateAutoRelease({
+      ...valid({
+        mergeSha,
+        baseSha,
+        previousVersions: versionsFromGitRef(baseSha),
+        currentVersions: versionsFromGitRef(mergeSha),
+      }),
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.eligible, expected.eligible);
+    if (expected.eligible) {
+      assert.equal(result.version, expected.version);
+      assert.equal(result.npm_dist_tag, expected.tag);
+    }
+  }
+});

--- a/.github/scripts/validate-github-release-inventory.mjs
+++ b/.github/scripts/validate-github-release-inventory.mjs
@@ -43,6 +43,7 @@ export function inspectReleaseInventory({
   expectedTargetCommitish,
   requiredSourceId = DOC_AGENT_SOURCE_ID,
   requireExisting = false,
+  allowPublishedForDraftRerun = false,
 } = {}) {
   const releaseTag = String(tag || "").trim();
   const matches = flattenReleasePages(pages).filter(
@@ -84,7 +85,8 @@ export function inspectReleaseInventory({
   const release = matches[0];
   if (
     typeof expectedDraft === "boolean" &&
-    Boolean(release.draft) !== expectedDraft
+    Boolean(release.draft) !== expectedDraft &&
+    !(expectedDraft && allowPublishedForDraftRerun && !release.draft)
   ) {
     errors.push(
       `GitHub Release ${releaseTag} draft=${Boolean(release.draft)}, expected ${expectedDraft}`,
@@ -160,6 +162,8 @@ export function main() {
       DOC_AGENT_SOURCE_ID,
     requireExisting:
       String(process.env.REQUIRE_EXISTING_RELEASE || "false").trim() === "true",
+    allowPublishedForDraftRerun:
+      String(process.env.ALLOW_PUBLISHED_FOR_DRAFT_RERUN || "false").trim() === "true",
   });
   process.stdout.write(`${JSON.stringify(report)}\n`);
   if (!report.ok) process.exitCode = 1;

--- a/.github/scripts/validate-github-release-inventory.test.mjs
+++ b/.github/scripts/validate-github-release-inventory.test.mjs
@@ -97,6 +97,19 @@ test("verifies target, release flags, and the exact production source id", () =>
   assert.ok(invalid.errors.some((error) => /exactly one Doc Agent source id/.test(error)));
 });
 
+test("accepts an already published matching release as an idempotent automatic Draft rerun", () => {
+  const report = inspectReleaseInventory({
+    pages: [[release({ draft: false })]],
+    tag: "v0.1.20",
+    expectedDraft: true,
+    expectedPrerelease: false,
+    expectedTargetCommitish: "abc123",
+    allowPublishedForDraftRerun: true,
+  });
+  assert.equal(report.ok, true);
+  assert.equal(report.state, "existing");
+});
+
 test("release workflow publishes committed main versions and pins recovery to npm gitHead", () => {
   const workflow = readFileSync(
     new URL("../workflows/release.yml", import.meta.url),
@@ -159,9 +172,19 @@ test("release workflow publishes committed main versions and pins recovery to np
   );
   assert.match(workflow, /GITHUB_RELEASE_VISIBILITY_ATTEMPTS: "12"/);
   assert.match(workflow, /GITHUB_RELEASE_VISIBILITY_INTERVAL_SECONDS: "10"/);
+  assert.match(workflow, /EXPECTED_RELEASE_DRAFT="\$\{CREATE_DRAFT_RELEASE\}"/);
+  assert.match(workflow, /ALLOW_PUBLISHED_FOR_DRAFT_RERUN="\$\{CREATE_DRAFT_RELEASE\}"/);
   assert.match(
     workflow,
     /Refusing to issue a second create request/,
+  );
+  assert.match(
+    workflow,
+    /Verified resume mode enabled; npm version exists, so publish is skipped/,
+  );
+  assert.match(
+    workflow,
+    /this automatic release is locked to merged commit \$\{AUTOMATIC_RELEASE_TARGET\}/,
   );
   assert.match(workflow, /report_exhausted_failure "github-release-create"/);
   assert.match(workflow, /report_exhausted_failure "github-release-verification"/);
@@ -176,9 +199,13 @@ test("release workflow publishes committed main versions and pins recovery to np
   assert.doesNotMatch(workflow, /release_branch/);
   assert.doesNotMatch(workflow, /create_version_pr/);
   assert.doesNotMatch(workflow, /gh release view/);
+  assert.match(
+    workflow,
+    /CREATE_DRAFT_RELEASE: \$\{\{ github\.event_name == 'pull_request' \|\| inputs\.recover_existing_npm_release == true \}\}/,
+  );
 });
 
-test("real publishes are branch-gated and reusable callers are immutable dry runs", () => {
+test("real publishes are version-transition-gated and reusable callers are immutable dry runs", () => {
   const releaseWorkflow = readFileSync(
     new URL("../workflows/release.yml", import.meta.url),
     "utf8",
@@ -186,6 +213,20 @@ test("real publishes are branch-gated and reusable callers are immutable dry run
   assert.match(
     releaseWorkflow,
     /Real releases must be dispatched from the protected default branch/,
+  );
+  assert.match(releaseWorkflow, /pull_request:\s*\n\s*types: \[closed\]/);
+  assert.match(releaseWorkflow, /resolve-auto-release\.mjs/);
+  assert.match(releaseWorkflow, /PR_BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/);
+  assert.doesNotMatch(releaseWorkflow, /\^release\/v/);
+  assert.match(releaseWorkflow, /--draft/);
+  assert.match(
+    releaseWorkflow,
+    /npm \$\{RELEASE_VERSION\} and tag \$\{release_tag\} were verified before the Draft was created/,
+  );
+  assert.ok(
+    releaseWorkflow.indexOf('npm publish --access public --tag "${NPM_DIST_TAG}"') <
+      releaseWorkflow.indexOf("release_flags+=(--draft)"),
+    "npm must be published and verified before the human-reviewed Draft is created",
   );
 
   for (const name of [
@@ -215,7 +256,15 @@ test("real publishes are branch-gated and reusable callers are immutable dry run
   );
   assert.match(preMergeWorkflow, /- "fix\/\*\*"/);
   assert.match(contractLintWorkflow, /- "fix\/\*\*"/);
+  assert.match(preMergeWorkflow, /pull_request:/);
+  assert.match(preMergeWorkflow, /Validate proposed four-file version transition/);
+  assert.match(preMergeWorkflow, /ref: \$\{\{ github\.sha \}\}/);
+  assert.doesNotMatch(contractLintWorkflow, /- "release\/v\*\*"/);
+  assert.doesNotMatch(preMergeWorkflow, /- "release\/v\*\*"/);
+  assert.match(contractLintWorkflow, /resolve-auto-release\.test\.mjs/);
   assert.match(contractLintWorkflow, /wait-for-npm-release\.test\.mjs/);
+  assert.match(releaseWorkflow, /^permissions:\s*\n\s*contents: read/m);
+  assert.match(releaseWorkflow, /publish:\s*\n[\s\S]*?permissions:\s*\n\s*contents: write/);
 });
 
 test("dry-run callers use least privilege and do not inherit all repository secrets", () => {
@@ -231,7 +280,7 @@ test("dry-run callers use least privilege and do not inherit all repository secr
   assert.match(releaseWorkflow, /NODE_AUTH_TOKEN: \$\{\{ secrets\.NPM_TOKEN \}\}/);
   assert.match(
     releaseWorkflow,
-    /persist-credentials: \$\{\{ inputs\.dry_run != true \}\}/,
+    /persist-credentials: \$\{\{ github\.event_name == 'pull_request' \|\| inputs\.dry_run != true \}\}/,
   );
   assert.match(dryRunWorkflow, /workflow_call:/);
   assert.match(dryRunWorkflow, /permissions:\s*\n\s*contents: read/);
@@ -323,7 +372,7 @@ test("dry-run callers use least privilege and do not inherit all repository secr
   );
   assert.match(
     contractLint,
-    /node --test \.github\/scripts\/validate-github-release-inventory\.test\.mjs \.github\/scripts\/validate-release-confirmation\.test\.mjs \.github\/scripts\/validate-release-source-version\.test\.mjs/,
+    /node --test \.github\/scripts\/resolve-auto-release\.test\.mjs \.github\/scripts\/validate-github-release-inventory\.test\.mjs \.github\/scripts\/validate-release-confirmation\.test\.mjs \.github\/scripts\/validate-release-source-version\.test\.mjs/,
   );
   assert.doesNotMatch(contractLint, /secrets:/);
   assert.doesNotMatch(contractLint, /contents: write/);

--- a/.github/scripts/validate-release-confirmation.mjs
+++ b/.github/scripts/validate-release-confirmation.mjs
@@ -48,12 +48,17 @@ export function validateReleaseChannel({ version, npmDistTag }) {
     github_release_prerelease: isPrerelease,
     docs_sync_expected: !isPrerelease,
     reason: isPrerelease
-      ? `prerelease version will publish on npm '${tag}', create a GitHub Prerelease, and skip formal Docs sync.`
-      : "stable version will publish on npm 'latest', create a published GitHub Release, and enter formal Docs sync.",
+      ? `prerelease version will publish on npm '${tag}', use a GitHub Prerelease, and skip formal Docs sync.`
+      : "stable version will publish on npm 'latest'; formal Docs sync starts only after its GitHub Release is published.",
   };
 }
 
-export function validateReleaseConfirmation({ version, dryRun, confirmation }) {
+export function validateReleaseConfirmation({
+  version,
+  dryRun,
+  confirmation,
+  automaticRelease = false,
+}) {
   const isDryRun = String(dryRun ?? "true").trim().toLowerCase() === "true";
   const expected = expectedReleaseConfirmation(version);
 
@@ -62,6 +67,15 @@ export function validateReleaseConfirmation({ version, dryRun, confirmation }) {
       ok: true,
       expected,
       reason: "dry_run=true; publish confirmation is not required.",
+    };
+  }
+
+  if (String(automaticRelease).trim().toLowerCase() === "true") {
+    return {
+      ok: true,
+      expected,
+      reason:
+        "trusted four-file version increase on merged main accepted; the reviewed version PR is the publish authorization and the GitHub Release will remain Draft for human review.",
     };
   }
 
@@ -77,7 +91,7 @@ export function validateReleaseConfirmation({ version, dryRun, confirmation }) {
     ok: false,
     expected,
     reason:
-      "dry_run=false would publish to npm and create a published GitHub Release; " +
+      "dry_run=false would perform release side effects; " +
       `publish_confirmation must exactly equal '${expected}'.`,
   };
 }
@@ -95,6 +109,7 @@ export function main(env = process.env) {
     version: env.RELEASE_VERSION,
     dryRun: env.DRY_RUN,
     confirmation: env.PUBLISH_CONFIRMATION,
+    automaticRelease: env.AUTOMATIC_RELEASE,
   });
 
   if (!result.ok) {

--- a/.github/scripts/validate-release-confirmation.test.mjs
+++ b/.github/scripts/validate-release-confirmation.test.mjs
@@ -95,6 +95,17 @@ test("requires exact publish confirmation before a real release", () => {
   );
 });
 
+test("uses a reviewed merged version PR as the confirmation for an automatic Draft release", () => {
+  const result = validateReleaseConfirmation({
+    version: "0.1.21",
+    dryRun: "false",
+    confirmation: "",
+    automaticRelease: "true",
+  });
+  assert.equal(result.ok, true);
+  assert.match(result.reason, /four-file version increase/);
+});
+
 test("exports deterministic beta and Docs routing metadata for workflows", () => {
   const output = join(mkdtempSync(join(tmpdir(), "openclaw-release-policy-")), "output");
   main({

--- a/.github/workflows/pre-merge-dry-run.yml
+++ b/.github/workflows/pre-merge-dry-run.yml
@@ -1,6 +1,10 @@
 name: OpenClaw Cloud Plugin — Pre-Merge Dry Run
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
   push:
     branches:
       - "docs-sync/**"
@@ -14,6 +18,8 @@ on:
       - ".github/workflows/workflow-contract-lint.yml"
       - ".github/scripts/draft-cloud-plugin-release-notes.mjs"
       - ".github/scripts/draft-cloud-plugin-release-notes.test.mjs"
+      - ".github/scripts/resolve-auto-release.mjs"
+      - ".github/scripts/resolve-auto-release.test.mjs"
       - ".github/scripts/validate-github-release-inventory.mjs"
       - ".github/scripts/validate-github-release-inventory.test.mjs"
       - ".github/scripts/validate-release-confirmation.mjs"
@@ -24,6 +30,10 @@ on:
       - ".github/scripts/wait-for-npm-release.test.mjs"
       - ".github/scripts/retry.sh"
       - "package.json"
+      - "openclaw.plugin.json"
+      - "moltbot.plugin.json"
+      - "clawdbot.plugin.json"
+      - ".github/release-notes/**"
       - "scripts/generate-telemetry-credentials.cjs"
       - "lib/**"
       - "test/*.test.mjs"
@@ -35,8 +45,35 @@ permissions:
   contents: read
 
 jobs:
+  release-candidate:
+    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Validate proposed four-file version transition
+        shell: bash
+        env:
+          EVENT_NAME: pull_request
+          PR_MERGED: "true"
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_MERGE_SHA: ${{ github.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node .github/scripts/resolve-auto-release.mjs
+
   secrets-preflight:
-    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
+    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - name: Confirm secretless branch inspection
@@ -48,7 +85,7 @@ jobs:
 
   dry-run:
     needs: secrets-preflight
-    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' }}
+    if: ${{ github.repository == 'MemTensor/MemOS-Cloud-OpenClaw-Plugin' && github.event_name == 'push' }}
     permissions:
       contents: read
     uses: ./.github/workflows/release-dry-run.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: OpenClaw Cloud Plugin — Publish & Release
 
 on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:
@@ -58,15 +62,147 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  classify_auto_release:
+    name: Classify automatic release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      eligible: ${{ steps.classify.outputs.eligible }}
+      reason: ${{ steps.classify.outputs.reason }}
+      previous_version: ${{ steps.classify.outputs.previous_version }}
+      version: ${{ steps.classify.outputs.version }}
+      npm_dist_tag: ${{ steps.classify.outputs.npm_dist_tag }}
+      target_sha: ${{ steps.classify.outputs.target_sha }}
+      release_notes_file: ${{ steps.classify.outputs.release_notes_file }}
+      release_notes_source: ${{ steps.classify.outputs.release_notes_source }}
+    steps:
+      - name: Check merged pull request boundary
+        id: gate
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_MERGED: ${{ github.event.pull_request.merged || false }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          inspect=false
+          reason="manual workflow dispatch"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            reason="closed pull request is not an eligible same-repository main merge"
+            if [ "${PR_MERGED}" = "true" ] && \
+               [ "${PR_BASE_REF}" = "main" ] && \
+               [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ]; then
+              inspect=true
+              reason="same-repository pull request merged into main; inspect committed versions"
+            fi
+          fi
+          {
+            echo "inspect=${inspect}"
+            echo "reason=${reason}"
+          } >> "${GITHUB_OUTPUT}"
+          {
+            echo "### OpenClaw cloud plugin release trigger"
+            echo
+            echo "- Inspect committed version transition: \`${inspect}\`"
+            echo "- Reason: ${reason}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - uses: actions/checkout@v7
+        if: ${{ steps.gate.outputs.inspect == 'true' }}
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v7
+        if: ${{ steps.gate.outputs.inspect == 'true' }}
+        with:
+          node-version: 22
+
+      - name: Resolve immutable automatic release
+        if: ${{ steps.gate.outputs.inspect == 'true' }}
+        id: release
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node .github/scripts/resolve-auto-release.mjs
+
+      - name: Load optional reviewed Release Notes
+        if: ${{ steps.release.outputs.eligible == 'true' }}
+        id: notes
+        shell: bash
+        env:
+          RELEASE_NOTES_PATH: ${{ steps.release.outputs.release_notes_path }}
+        run: |
+          set -euo pipefail
+          if [ -f "${RELEASE_NOTES_PATH}" ]; then
+            {
+              echo "release_notes_source=checked_in"
+              echo "release_notes_file=${RELEASE_NOTES_PATH}"
+            } >> "${GITHUB_OUTPUT}"
+            echo "Using reviewed Release Notes from ${RELEASE_NOTES_PATH}."
+          else
+            echo "release_notes_source=doc_agent" >> "${GITHUB_OUTPUT}"
+            echo "release_notes_file=" >> "${GITHUB_OUTPUT}"
+            echo "${RELEASE_NOTES_PATH} is absent; 106 Doc Agent will draft from immutable git evidence."
+          fi
+
+      - name: Export automatic release inputs
+        if: ${{ steps.gate.outputs.inspect == 'true' }}
+        id: classify
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          PREVIOUS_VERSION: ${{ steps.release.outputs.previous_version }}
+          NPM_DIST_TAG: ${{ steps.release.outputs.npm_dist_tag }}
+          TARGET_SHA: ${{ steps.release.outputs.target_sha }}
+          ELIGIBLE: ${{ steps.release.outputs.eligible }}
+          RELEASE_REASON: ${{ steps.release.outputs.reason }}
+          RELEASE_NOTES_FILE: ${{ steps.notes.outputs.release_notes_file }}
+          RELEASE_NOTES_SOURCE: ${{ steps.notes.outputs.release_notes_source }}
+        run: |
+          set -euo pipefail
+          {
+            echo "eligible=${ELIGIBLE}"
+            echo "reason=${RELEASE_REASON}"
+            echo "previous_version=${PREVIOUS_VERSION}"
+            echo "version=${VERSION}"
+            echo "npm_dist_tag=${NPM_DIST_TAG}"
+            echo "target_sha=${TARGET_SHA}"
+            echo "release_notes_source=${RELEASE_NOTES_SOURCE}"
+            echo "release_notes_file=${RELEASE_NOTES_FILE}"
+          } >> "${GITHUB_OUTPUT}"
+          {
+            echo
+            echo "- Automatic release: \`${ELIGIBLE}\`"
+            echo "- Version transition: \`${PREVIOUS_VERSION:-unchanged} -> ${VERSION:-unchanged}\`"
+            echo "- Result: ${RELEASE_REASON}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   publish:
+    needs: classify_auto_release
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        needs.classify_auto_release.outputs.eligible == 'true'
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
       - name: Validate immutable publish ref
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != true }}
         shell: bash
         env:
           RELEASE_GIT_REF: ${{ inputs.git_ref }}
@@ -89,9 +225,13 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.git_ref || github.ref }}
+          ref: >-
+            ${{
+              github.event_name == 'pull_request' && needs.classify_auto_release.outputs.target_sha ||
+              inputs.git_ref || github.ref
+            }}
           fetch-depth: 0
-          persist-credentials: ${{ inputs.dry_run != true }}
+          persist-credentials: ${{ github.event_name == 'pull_request' || inputs.dry_run != true }}
 
       - uses: actions/setup-node@v7
         with:
@@ -102,13 +242,14 @@ jobs:
         id: release_policy
         shell: bash
         env:
-          RELEASE_VERSION: ${{ inputs.version }}
-          NPM_DIST_TAG: ${{ inputs.tag }}
-          DRY_RUN: ${{ inputs.dry_run }}
-          PUBLISH_CONFIRMATION: ${{ inputs.publish_confirmation }}
-          RELEASE_FAULT_CASE: ${{ inputs.fault_case }}
-          RELEASE_GIT_REF: ${{ inputs.git_ref }}
-          RECOVER_EXISTING_NPM_RELEASE: ${{ inputs.recover_existing_npm_release }}
+          RELEASE_VERSION: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.version || inputs.version }}
+          NPM_DIST_TAG: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.npm_dist_tag || inputs.tag }}
+          DRY_RUN: ${{ github.event_name == 'pull_request' && 'false' || inputs.dry_run }}
+          PUBLISH_CONFIRMATION: ${{ github.event_name == 'pull_request' && '' || inputs.publish_confirmation }}
+          RELEASE_FAULT_CASE: ${{ github.event_name == 'pull_request' && 'none' || inputs.fault_case }}
+          RELEASE_GIT_REF: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.target_sha || inputs.git_ref }}
+          RECOVER_EXISTING_NPM_RELEASE: ${{ github.event_name == 'pull_request' && 'false' || inputs.recover_existing_npm_release }}
+          AUTOMATIC_RELEASE: ${{ github.event_name == 'pull_request' }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
@@ -132,11 +273,11 @@ jobs:
             echo "::error::fault_case is only allowed when dry_run=true."
             exit 1
           fi
-          if [ "${DRY_RUN}" != "true" ] && [ "${GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+          if [ "${DRY_RUN}" != "true" ] && [ "${AUTOMATIC_RELEASE}" != "true" ] && [ "${GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
             echo "::error::Real releases must be dispatched from the protected default branch ${DEFAULT_BRANCH}; got ${GITHUB_REF}."
             exit 1
           fi
-          if [ "${DRY_RUN}" != "true" ]; then
+          if [ "${DRY_RUN}" != "true" ] && [ "${AUTOMATIC_RELEASE}" != "true" ]; then
             if [ "${RECOVER_EXISTING_NPM_RELEASE}" != "true" ] && ! [[ "${RELEASE_GIT_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
               echo "::error::Normal real releases require git_ref to be the exact 40-character source_commit approved in the dry-run."
               exit 1
@@ -161,7 +302,9 @@ jobs:
         shell: bash
         env:
           PACKAGE_NAME: "@memtensor/memos-cloud-openclaw-plugin"
-          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_VERSION: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.version || inputs.version }}
+          AUTOMATIC_RELEASE: ${{ github.event_name == 'pull_request' }}
+          AUTOMATIC_RELEASE_TARGET: ${{ needs.classify_auto_release.outputs.target_sha }}
         run: |
           set -euo pipefail
           release_tag="v${RELEASE_VERSION#v}"
@@ -236,6 +379,10 @@ jobs:
           npm_git_head=""
           if npm_version_exists; then
             npm_git_head="$(npm_release_git_head)"
+            if [ "${AUTOMATIC_RELEASE}" = "true" ] && [ "${npm_git_head}" != "${AUTOMATIC_RELEASE_TARGET}" ]; then
+              echo "::error::npm records gitHead ${npm_git_head} for ${PACKAGE_NAME}@${RELEASE_VERSION}, but this automatic release is locked to merged commit ${AUTOMATIC_RELEASE_TARGET}."
+              exit 1
+            fi
             if ! git cat-file -e "${npm_git_head}^{commit}" 2>/dev/null; then
               bash .github/scripts/retry.sh --label "fetch npm gitHead ${npm_git_head}" -- \
                 git fetch --no-tags origin "${npm_git_head}"
@@ -288,7 +435,7 @@ jobs:
       - name: Validate committed release source version
         shell: bash
         env:
-          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_VERSION: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.version || inputs.version }}
           RELEASE_SOURCE_REF: ${{ steps.release_source.outputs.evidence_ref }}
         run: |
           set -euo pipefail
@@ -311,11 +458,12 @@ jobs:
       - name: Draft GitHub Release notes
         id: release_notes
         env:
-          RELEASE_VERSION: ${{ inputs.version }}
-          RELEASE_TAG: v${{ inputs.version }}
+          RELEASE_VERSION: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.version || inputs.version }}
+          RELEASE_TAG: v${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.version || inputs.version }}
           RELEASE_EVIDENCE_REF: ${{ steps.release_source.outputs.evidence_ref }}
-          MANUAL_RELEASE_NOTES: ${{ inputs.release_notes }}
-          RELEASE_FAULT_CASE: ${{ inputs.fault_case }}
+          MANUAL_RELEASE_NOTES: ${{ github.event_name == 'pull_request' && '' || inputs.release_notes }}
+          MANUAL_RELEASE_NOTES_FILE: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.release_notes_file || '' }}
+          RELEASE_FAULT_CASE: ${{ github.event_name == 'pull_request' && 'none' || inputs.fault_case }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
           DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
@@ -326,9 +474,10 @@ jobs:
         shell: bash
         env:
           DRAFT_STEP_OUTCOME: ${{ steps.release_notes.outcome }}
-          DRY_RUN: ${{ inputs.dry_run }}
-          RELEASE_VERSION: ${{ inputs.version }}
-          FAULT_CASE: ${{ inputs.fault_case }}
+          DRY_RUN: ${{ github.event_name == 'pull_request' && 'false' || inputs.dry_run }}
+          RELEASE_VERSION: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.version || inputs.version }}
+          FAULT_CASE: ${{ github.event_name == 'pull_request' && 'none' || inputs.fault_case }}
+          RELEASE_NOTES_SOURCE: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.release_notes_source || (inputs.release_notes != '' && 'manual_input' || 'doc_agent') }}
           RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
           EVIDENCE_FILE: ${{ steps.release_notes.outputs.evidence_file }}
           DRAFT_FILE: ${{ steps.release_notes.outputs.draft_file }}
@@ -432,6 +581,7 @@ jobs:
             echo "- github_release_prerelease: ${GITHUB_RELEASE_PRERELEASE}"
             echo "- docs_sync_expected: ${DOCS_SYNC_EXPECTED}"
             echo "- fault_case: ${FAULT_CASE}"
+            echo "- release_notes_source: ${RELEASE_NOTES_SOURCE}"
             echo "- draft_used: ${DRAFT_USED:-unknown}"
             echo "- previous_tag: ${PREVIOUS_TAG:-n/a}"
             echo "- current_tag: ${CURRENT_TAG:-n/a}"
@@ -476,6 +626,7 @@ jobs:
             echo "- github_release_prerelease: \`${GITHUB_RELEASE_PRERELEASE}\`"
             echo "- docs_sync_expected: \`${DOCS_SYNC_EXPECTED}\`"
             echo "- fault_case: \`${FAULT_CASE}\`"
+            echo "- release_notes_source: \`${RELEASE_NOTES_SOURCE}\`"
             echo "- draft_used: \`${DRAFT_USED:-unknown}\`"
             echo "- previous_tag: \`${PREVIOUS_TAG:-n/a}\`"
             echo "- current_tag: \`${CURRENT_TAG:-n/a}\`"
@@ -504,22 +655,25 @@ jobs:
           if-no-files-found: error
 
       - name: Stop before publish in dry run
-        if: ${{ inputs.dry_run == true }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
         run: |
           echo "::notice::dry_run=true; skipped npm publish, tag, and GitHub Release."
 
       - name: Publish to npm
         id: publish_npm
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ github.event_name == 'pull_request' || inputs.dry_run != true }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ github.token }}
           PACKAGE_NAME: "@memtensor/memos-cloud-openclaw-plugin"
-          RELEASE_VERSION: ${{ inputs.version }}
-          RELEASE_TAG: v${{ inputs.version }}
-          NPM_DIST_TAG: ${{ inputs.tag }}
+          RELEASE_VERSION: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.version || inputs.version }}
+          RELEASE_TAG: v${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.version || inputs.version }}
+          NPM_DIST_TAG: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.npm_dist_tag || inputs.tag }}
+          CREATE_DRAFT_RELEASE: ${{ github.event_name == 'pull_request' || inputs.recover_existing_npm_release == true }}
           EXPECTED_RELEASE_PRERELEASE: ${{ steps.release_policy.outputs.github_release_prerelease }}
-          RECOVER_EXISTING_NPM_RELEASE: ${{ inputs.recover_existing_npm_release }}
+          RECOVER_EXISTING_NPM_RELEASE: ${{ github.event_name == 'pull_request' && 'false' || inputs.recover_existing_npm_release }}
+          AUTOMATIC_RELEASE: ${{ github.event_name == 'pull_request' }}
+          AUTOMATIC_RELEASE_TARGET: ${{ needs.classify_auto_release.outputs.target_sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
@@ -696,11 +850,12 @@ jobs:
             local expected_target="${1:-}"
             RELEASE_INVENTORY_FILE="${release_inventory_file}" \
               RELEASE_TAG="${release_tag}" \
-              EXPECTED_RELEASE_DRAFT=false \
+              EXPECTED_RELEASE_DRAFT="${CREATE_DRAFT_RELEASE}" \
               EXPECTED_RELEASE_PRERELEASE="${expected_release_prerelease}" \
               EXPECTED_RELEASE_TARGET="${expected_target}" \
               REQUIRED_DOC_AGENT_SOURCE_ID=openclaw-cloud-plugin \
               REQUIRE_EXISTING_RELEASE=false \
+              ALLOW_PUBLISHED_FOR_DRAFT_RERUN="${CREATE_DRAFT_RELEASE}" \
               node .github/scripts/validate-github-release-inventory.mjs
           }
 
@@ -729,6 +884,10 @@ jobs:
 
           if npm_version_exists; then
             release_commit_sha="$(npm_release_git_head)"
+            if [ "${AUTOMATIC_RELEASE}" = "true" ] && [ "${release_commit_sha}" != "${AUTOMATIC_RELEASE_TARGET}" ]; then
+              echo "::error::npm records gitHead ${release_commit_sha} for ${PACKAGE_NAME}@${RELEASE_VERSION}, but this automatic release is locked to merged commit ${AUTOMATIC_RELEASE_TARGET}."
+              exit 1
+            fi
             ensure_commit_available "${release_commit_sha}"
             validate_release_commit_versions "${release_commit_sha}"
 
@@ -738,8 +897,8 @@ jobs:
             fi
             if [ "${tag_exists}" = "true" ] && [ "${release_exists}" = "true" ]; then
               echo "${PACKAGE_NAME}@${RELEASE_VERSION}, ${release_tag}, and its validated GitHub Release already exist; treating this as an idempotent rerun."
-            elif [ "${RECOVER_EXISTING_NPM_RELEASE}" = "true" ]; then
-              echo "Recovery mode enabled; npm version exists, so publish is skipped and missing GitHub metadata will target npm gitHead ${release_commit_sha}."
+            elif [ "${RECOVER_EXISTING_NPM_RELEASE}" = "true" ] || [ "${AUTOMATIC_RELEASE}" = "true" ]; then
+              echo "Verified resume mode enabled; npm version exists, so publish is skipped and missing GitHub metadata will target npm gitHead ${release_commit_sha}."
             else
               missing=()
               if [ "${tag_exists}" != "true" ]; then
@@ -769,13 +928,23 @@ jobs:
               echo "::error::Could not resolve the protected default branch ${DEFAULT_BRANCH}."
               exit 1
             fi
-            if [ "${remote_default_sha}" != "${source_commit_sha}" ]; then
+            if [ "${AUTOMATIC_RELEASE}" = "true" ]; then
+              if [ "${source_commit_sha}" != "${AUTOMATIC_RELEASE_TARGET}" ]; then
+                echo "::error::Checked-out source ${source_commit_sha} does not match the merged version PR target ${AUTOMATIC_RELEASE_TARGET}."
+                exit 1
+              fi
+              git fetch --no-tags origin "${DEFAULT_BRANCH}"
+              if ! git merge-base --is-ancestor "${source_commit_sha}" "origin/${DEFAULT_BRANCH}"; then
+                echo "::error::Merged release target ${source_commit_sha} is no longer an ancestor of ${DEFAULT_BRANCH}."
+                exit 1
+              fi
+            elif [ "${remote_default_sha}" != "${source_commit_sha}" ]; then
               echo "::error::The checked-out release source ${source_commit_sha} is no longer the head of ${DEFAULT_BRANCH} (${remote_default_sha}). Rerun the workflow from the latest main commit."
               exit 1
             fi
             release_commit_sha="${source_commit_sha}"
             validate_release_commit_versions "${release_commit_sha}"
-            echo "Publishing the already-reviewed ${DEFAULT_BRANCH} commit ${release_commit_sha}; no source files or release branch will be created."
+            echo "Publishing the already-reviewed ${DEFAULT_BRANCH} commit ${release_commit_sha}; no source files or version PR will be created by Actions."
 
             attempt_dir="${RUNNER_TEMP}/openclaw-cloud-plugin-npm-publish-attempts"
             mkdir -p "${attempt_dir}"
@@ -827,11 +996,12 @@ jobs:
           echo "release_commit_sha=${release_commit_sha}" >> "${GITHUB_OUTPUT}"
 
       - name: Create release tag and GitHub Release
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ github.event_name == 'pull_request' || inputs.dry_run != true }}
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ inputs.version }}
-          NPM_DIST_TAG: ${{ inputs.tag }}
+          RELEASE_VERSION: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.version || inputs.version }}
+          NPM_DIST_TAG: ${{ github.event_name == 'pull_request' && needs.classify_auto_release.outputs.npm_dist_tag || inputs.tag }}
+          CREATE_DRAFT_RELEASE: ${{ github.event_name == 'pull_request' || inputs.recover_existing_npm_release == true }}
           EXPECTED_RELEASE_PRERELEASE: ${{ steps.release_policy.outputs.github_release_prerelease }}
           RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
           RELEASE_COMMIT_SHA: ${{ steps.publish_npm.outputs.release_commit_sha }}
@@ -919,11 +1089,12 @@ jobs:
             local require_existing="$1"
             RELEASE_INVENTORY_FILE="${release_inventory_file}" \
               RELEASE_TAG="${release_tag}" \
-              EXPECTED_RELEASE_DRAFT=false \
+              EXPECTED_RELEASE_DRAFT="${CREATE_DRAFT_RELEASE}" \
               EXPECTED_RELEASE_PRERELEASE="${expected_release_prerelease}" \
               EXPECTED_RELEASE_TARGET="${RELEASE_COMMIT_SHA}" \
               REQUIRED_DOC_AGENT_SOURCE_ID=openclaw-cloud-plugin \
               REQUIRE_EXISTING_RELEASE="${require_existing}" \
+              ALLOW_PUBLISHED_FOR_DRAFT_RERUN="${CREATE_DRAFT_RELEASE}" \
               node .github/scripts/validate-github-release-inventory.mjs
           }
           create_release_if_missing() {
@@ -934,6 +1105,10 @@ jobs:
             if [ "${expected_release_prerelease}" = "true" ]; then
               release_flags+=(--prerelease)
               echo "Marking GitHub Release ${release_tag} as prerelease because version=${RELEASE_VERSION}, npm_dist_tag=${NPM_DIST_TAG}."
+            fi
+            if [ "${CREATE_DRAFT_RELEASE}" = "true" ]; then
+              release_flags+=(--draft)
+              echo "Creating GitHub Release ${release_tag} as a Draft for human review. Publishing the Draft is the only Docs webhook boundary."
             fi
 
             for attempt in 1 2 3; do
@@ -1047,3 +1222,14 @@ jobs:
           fi
 
           create_release_if_missing
+
+          if [ "${CREATE_DRAFT_RELEASE}" = "true" ]; then
+            {
+              echo "### Draft Release ready for review"
+              echo
+              echo "- npm ${RELEASE_VERSION} and tag ${release_tag} were verified before the Draft was created."
+              echo "- Review the Draft Release body and Docs preview."
+              echo "- Stable release: click Publish only after review; that release.published event triggers 106."
+              echo "- Prerelease: publishing remains a GitHub Prerelease and 106 must skip formal Docs sync."
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi

--- a/.github/workflows/workflow-contract-lint.yml
+++ b/.github/workflows/workflow-contract-lint.yml
@@ -1,6 +1,21 @@
 name: OpenClaw Cloud Plugin — Workflow Contract Lint
 
 on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - ".github/scripts/resolve-auto-release.mjs"
+      - ".github/scripts/resolve-auto-release.test.mjs"
+      - ".github/scripts/validate-github-release-inventory.mjs"
+      - ".github/scripts/validate-github-release-inventory.test.mjs"
+      - ".github/scripts/validate-release-confirmation.mjs"
+      - ".github/scripts/validate-release-confirmation.test.mjs"
+      - ".github/scripts/validate-release-source-version.mjs"
+      - ".github/scripts/validate-release-source-version.test.mjs"
+      - ".github/scripts/wait-for-npm-release.mjs"
+      - ".github/scripts/wait-for-npm-release.test.mjs"
   push:
     branches:
       - main
@@ -10,6 +25,8 @@ on:
       - ".github/workflows/**"
       - ".github/scripts/validate-github-release-inventory.mjs"
       - ".github/scripts/validate-github-release-inventory.test.mjs"
+      - ".github/scripts/resolve-auto-release.mjs"
+      - ".github/scripts/resolve-auto-release.test.mjs"
       - ".github/scripts/validate-release-confirmation.mjs"
       - ".github/scripts/validate-release-confirmation.test.mjs"
       - ".github/scripts/validate-release-source-version.mjs"
@@ -61,4 +78,4 @@ jobs:
 
       - name: Validate reusable workflow boundaries
         shell: bash
-        run: node --test .github/scripts/validate-github-release-inventory.test.mjs .github/scripts/validate-release-confirmation.test.mjs .github/scripts/validate-release-source-version.test.mjs .github/scripts/wait-for-npm-release.test.mjs
+        run: node --test .github/scripts/resolve-auto-release.test.mjs .github/scripts/validate-github-release-inventory.test.mjs .github/scripts/validate-release-confirmation.test.mjs .github/scripts/validate-release-source-version.test.mjs .github/scripts/wait-for-npm-release.test.mjs

--- a/docs/release-owner-runbook.md
+++ b/docs/release-owner-runbook.md
@@ -1,0 +1,130 @@
+# OpenClaw 云插件自动 Draft Release 发布说明
+
+## 一句话结论
+
+发布人员不需要新建固定名称的 `release/*` 分支，也不需要手工填写 npm tag 或 40 位 commit。
+将四个版本文件在同一个受审 PR 中一致升级并合入 `main` 后，系统会自动判断是 Beta 还是稳定版，
+发布并验证 npm，随后创建 GitHub Draft Release；发布负责人检查 Draft 后再点击 **Publish**。
+
+这套流程不会让 GitHub Actions 新建或批准 PR，因此仓库不需要开启
+**Allow GitHub Actions to create and approve pull requests**。版本修改仍由开发人员通过普通 PR 提交，Actions
+只负责消费已经合入 `main` 的代码、发布 npm、创建 tag 和 Draft Release。
+
+## 发布负责人怎么操作
+
+以稳定版 `0.1.21` 为例：
+
+1. 使用团队现有分支，例如 `test` 或普通版本准备分支，不要求特定名称。
+2. 将下列四个文件的 `version` 全部从当前版本改成 `0.1.21`：
+   - `package.json`
+   - `openclaw.plugin.json`
+   - `moltbot.plugin.json`
+   - `clawdbot.plugin.json`
+3. 可选：添加 `.github/release-notes/v0.1.21.md`。不添加时由 106 根据 Git 证据自动生成。
+4. 提交目标为 `main` 的 PR，确认测试和版本检查通过后由有权限人员合并。
+5. 合并后打开 Actions 中的 **OpenClaw Cloud Plugin — Publish & Release**，确认自动 run 为绿色。
+6. 打开仓库 Releases，检查系统创建的 `v0.1.21` Draft：
+   - 版本和目标 commit 正确；
+   - Release Notes 准确；
+   - 中英文官网预览准确；
+   - npm `0.1.21` 已经通过 `latest` 可见。
+7. 确认无误后点击 **Publish release**。只有这一步会产生稳定版 `release.published` webhook，并让 106 创建 MemOS-Docs PR。
+
+合并前会有一条只读的版本门禁，只比较 PR 合并预览与当前 `main` 的四个版本值，不读取发布 Secrets，
+也不会发布 npm、创建 tag 或 Release。真正副作用只发生在合并后的自动 Workflow。
+
+Beta 示例：将四个文件从旧版本一致升级为 `0.1.21-beta.0`。系统自动选择 npm `beta`，创建
+GitHub Prerelease Draft；Publish 后 106 必须成功跳过正式官网同步。
+
+## 系统怎样判断这是一次发版
+
+系统比较 PR 合入前的 `main` 与合入后的精确 merge commit。只有同时满足以下条件才自动发版：
+
+1. PR 已合入 `main`，并且来自当前仓库而不是 Fork；
+2. 四个版本文件在合入前版本一致；
+3. 四个版本文件在合入后版本一致；
+4. 四个版本值都在本次 PR 中发生升级；
+5. 新版本是严格 SemVer，并且优先级高于旧版本；
+6. npm、GitHub tag 和 Release 状态没有冲突。
+
+如果四个版本值完全没变，这是普通代码合并，自动跳过，不会发布。只改一部分版本文件、四个版本不一致、
+版本倒退或使用 build metadata 时会失败停止，避免产生半正确的包。
+
+允许的升级示例：
+
+```text
+0.1.20 -> 0.1.21-beta.0
+0.1.21-beta.0 -> 0.1.21-beta.1
+0.1.21-beta.1 -> 0.1.21
+```
+
+## Beta 与稳定版的区别
+
+| 合入后的版本 | npm dist-tag | GitHub Draft | Publish 后的 Docs 行为 |
+|---|---|---|---|
+| `0.1.21-beta.0` | `beta` | Prerelease Draft | 106 成功跳过，不创建正式 Docs PR |
+| `0.1.21-alpha.1` | `alpha` | Prerelease Draft | 106 成功跳过，不创建正式 Docs PR |
+| `0.1.21-rc.1` | `next` | Prerelease Draft | 106 成功跳过，不创建正式 Docs PR |
+| `0.1.21` | `latest` | 正常 Draft | 人工 Publish 后由 106 创建 Docs PR |
+
+## 为什么 npm 在 Draft 之前发布
+
+GitHub Draft 一旦被人工 Publish，`release.published` webhook 会立即到达 106。如果这时才异步发布 npm，
+就可能出现官网同步已经开始、npm 却失败或暂时不可见的半发布状态。
+
+因此本仓库选择：
+
+```text
+版本 PR 合入 main
+-> 校验四文件版本与 Release Notes
+-> npm publish + 校验 version/gitHead/dist-tag
+-> 创建不可变 tag 和 Draft Release
+-> 人工 Publish
+-> 稳定版进入 106 Docs PR，预发布版成功跳过
+```
+
+合并版本 PR 表示已经批准代码和 npm 发布；Draft 的人工边界用于最后确认 GitHub Release 和官网文案。
+如果团队要求“人工审批前 npm 也不能发布”，需要改用受保护 GitHub Environment 的审批按钮，不能只依赖原生 Draft。
+
+## Release Notes 规则
+
+### 默认方式：106 自动生成
+
+不创建 `.github/release-notes/v<版本>.md`。Workflow 会基于真实 tag range 和本次 merge commit 调用 106，
+生成中英文内容、真实 `source_refs`、质量报告和 Docs Preview。
+
+稳定版会跳过中间 prerelease tag，以上一个稳定 tag 为 evidence 基线，避免 Beta 已经承载的真实功能在
+`beta -> stable` 时被漏掉。
+
+### 人工方式：随版本 PR 提交
+
+创建 `.github/release-notes/v<版本>.md`。文件必须包含：
+
+- `## Changelog` 公开 Markdown；
+- 隐藏的 `doc-agent-release-notes-json` 双语证据块；
+- 唯一的 `<!-- doc-agent: source-id=openclaw-cloud-plugin -->`。
+
+人工文件也必须通过 source ref、覆盖率、双语和长度检查，不能绕过质量门禁。
+
+## 哪些合并不会发布
+
+分支名不决定是否发版。`test`、`feature/*`、`fix/*`、`docs-sync/*` 都可以合入 `main`：
+
+- 四个版本值没有变化：正常跳过发布；
+- 四个版本值全部一致升级：进入自动发布；
+- 只有部分版本变化或版本不一致：检查失败，要求修正。
+
+## 失败怎么处理
+
+- 合并前版本检查失败：继续修改原 PR，四个版本一致且确实升级后再合并。
+- 106 文案生成失败：不会发布 npm、tag 或 Draft；修复 endpoint、证据或人工 notes 后再处理。
+- npm 发布失败且 registry 没有正确版本：不会创建 tag/Draft；根据 Action 错误处理，禁止猜测成功。
+- npm 已成功但同一次自动任务尚未创建 tag/Draft：可先点击 Re-run；系统确认 npm `gitHead` 与原合并 commit 完全相同后，只补缺失元数据，不会重复发布 npm。
+- npm 已成功，但 tag/Draft 未创建：使用现有 Workflow 的显式 Recovery；它从 npm `gitHead` 补齐元数据，不会重复发布 npm，并且仍然只创建 Draft 等待人工 Publish。
+- Draft 文案不通过：不要点 Publish。修订 Draft 时不得删除或损坏隐藏的双语 evidence payload 和 `source-id`。
+- tag 指向、npm `gitHead`、四文件版本任一冲突：必须人工排查，Workflow 不会移动已有 tag。
+
+## 旧的手动入口
+
+**OpenClaw Cloud Plugin — Publish & Release** 的 `Run workflow` 仍保留给历史 Dry-run、故障注入和部分失败 Recovery。
+正常新版本发布直接走“四个版本文件一致升级并合入 `main`”，不再要求发布人员填写旧表单。


### PR DESCRIPTION
## Summary

- trigger the cloud-plugin release workflow after a same-repository PR is merged into `main` and all four committed version files increase consistently
- derive stable/prerelease npm channels automatically, publish and verify npm, then create an immutable tag and a human-reviewed Draft Release
- keep stable Docs synchronization behind the manual `Publish release` boundary; prereleases remain excluded from formal Docs synchronization
- add fail-closed version gates, immutable-source checks, bounded npm/GitHub propagation verification, idempotent reruns, and explicit metadata recovery
- support optional reviewed `.github/release-notes/v<version>.md` files while retaining the 106 evidence-backed draft path
- document the release-owner workflow and remove any need for Actions to create version-update PRs

## Release behavior

- ordinary merges with unchanged versions are skipped
- partial, inconsistent, downgraded, or ambiguous version transitions fail closed
- stable versions use npm `latest` and create a normal Draft Release
- beta/alpha/other prereleases use `beta`/`alpha`/`next` and create a Prerelease Draft
- npm version, `gitHead`, and dist-tag are verified before tag/Draft creation
- a rerun after npm success verifies the original merge commit and only completes missing tag/Release metadata

## Validation

- release-script tests: 76 passed
- plugin tests: 139 passed
- actionlint: passed
- npm pack dry-run: passed (17 files)
- `git diff --check`: passed
- historical replay: PR #152 detected as `0.1.20-beta.0`, PR #155 as stable `0.1.20`, PR #156 correctly skipped as version-unchanged

## Review notes

This PR does not change any of the four package version values, so merging this PR must not publish npm or create a release. The first real end-to-end automatic publish will occur only when a later reviewed PR consistently increases all four version files.

The repository does not need to enable **Allow GitHub Actions to create and approve pull requests**. Actions consume the reviewed `main` commit and never create a version-writeback PR.
